### PR TITLE
Fix failing to unregister addon

### DIFF
--- a/BlenderMalt/MaltProperties.py
+++ b/BlenderMalt/MaltProperties.py
@@ -319,7 +319,7 @@ def unregister():
     del bpy.types.Object.malt_parameters
     del bpy.types.Material.malt_parameters
     del bpy.types.Mesh.malt_parameters
-    del bpy.types.Font.malt_parameters
+    del bpy.types.Curve.malt_parameters
     del bpy.types.Light.malt_parameters
 
     bpy.app.handlers.depsgraph_update_post.append(depsgraph_update)


### PR DESCRIPTION
I got an error as follows trying to unregister the addon:
```
Traceback (most recent call last):
  File "/home/irie/Git/Blender/build_linux_full/bin/2.90/scripts/modules/addon_utils.py", line 434, in disable
    mod.unregister()
  File "/home/irie/.config/blender/2.90/scripts/addons/BlenderMalt/__init__.py", line 108, in unregister
    module.unregister()
  File "/home/irie/.config/blender/2.90/scripts/addons/BlenderMalt/MaltProperties.py", line 322, in unregister
    del bpy.types.Font.malt_parameters
AttributeError: 'RNA_Types' object has no attribute 'Font'

Error: Traceback (most recent call last):
  File "/home/irie/Git/Blender/build_linux_full/bin/2.90/scripts/modules/addon_utils.py", line 434, in disable
    mod.unregister()
  File "/home/irie/.config/blender/2.90/scripts/addons/BlenderMalt/__init__.py", line 108, in unregister
    module.unregister()
  File "/home/irie/.config/blender/2.90/scripts/addons/BlenderMalt/MaltProperties.py", line 322, in unregister
    del bpy.types.Font.malt_parameters
AttributeError: 'RNA_Types' object has no attribute 'Font'
```
In `unregister()`, `bpy.types.Font` should be changed to `bpy.types.Curve`.
