### PR TITLE
fix separator of path to linux

### DIFF
--- a/BlenderMalt/MaltMaterial.py
+++ b/BlenderMalt/MaltMaterial.py
@@ -2,6 +2,7 @@
 
 import os
 import bpy
+from BlenderMalt import malt_path_getter, malt_path_setter
 from . MaltProperties import MaltPropertyGroup
 
 _MATERIALS = {}
@@ -24,8 +25,10 @@ class MaltMaterial(bpy.types.PropertyGroup):
     
     def poll_tree(self, object):
         return object.bl_idname == 'MaltTree'
+
+    shader_source : bpy.props.StringProperty(name="Shader Source", subtype='FILE_PATH', update=update_source,
+        set=malt_path_setter('shader_source'), get=malt_path_getter('shader_source'))
         
-    shader_source : bpy.props.StringProperty(name="Shader Source", subtype='FILE_PATH', update=update_source)
     shader_nodes : bpy.props.PointerProperty(name="Node Tree", type=bpy.types.NodeTree, update=update_nodes, poll=poll_tree)
     compiler_error : bpy.props.StringProperty(name="Compiler Error")
 

--- a/BlenderMalt/MaltNodes.py
+++ b/BlenderMalt/MaltNodes.py
@@ -4,6 +4,7 @@ import os, time
 from itertools import chain
 from Malt.Parameter import Parameter, Type
 import bpy
+from BlenderMalt import malt_path_getter, malt_path_setter
 from . MaltProperties import MaltPropertyGroup
 from . import MaltPipeline
 
@@ -27,7 +28,8 @@ class MaltTree(bpy.types.NodeTree):
     
     graph_type: bpy.props.StringProperty(name='Type')
 
-    library_source : bpy.props.StringProperty(name="Shader Library", subtype='FILE_PATH')
+    library_source : bpy.props.StringProperty(name="Shader Library", subtype='FILE_PATH',
+        set=malt_path_setter('library_source'), get=malt_path_getter('library_source'))
 
     disable_updates : bpy.props.BoolProperty(name="Disable Updates", default=False)
 

--- a/BlenderMalt/MaltPipeline.py
+++ b/BlenderMalt/MaltPipeline.py
@@ -38,6 +38,7 @@ class MaltPipeline(bpy.types.PropertyGroup):
         
         #TODO: Sync all scenes. Only one active pipeline per Blender instance is supported atm.
         pipeline = self.pipeline
+        pipeline = pipeline.replace('\\', '/')
         if pipeline == '':
             current_dir = os.path.dirname(os.path.abspath(__file__))
             default_pipeline = os.path.join(current_dir,'.MaltPath','Malt','Pipelines','NPR_Pipeline','NPR_Pipeline_Nodes.py')

--- a/BlenderMalt/MaltPipeline.py
+++ b/BlenderMalt/MaltPipeline.py
@@ -2,6 +2,7 @@
 
 import os, platform, time
 import bpy
+from BlenderMalt import malt_path_getter, malt_path_setter
 from . import MaltMaterial, MaltMeshes, MaltTextures
 
 __BRIDGE = None
@@ -38,7 +39,6 @@ class MaltPipeline(bpy.types.PropertyGroup):
         
         #TODO: Sync all scenes. Only one active pipeline per Blender instance is supported atm.
         pipeline = self.pipeline
-        pipeline = pipeline.replace('\\', '/')
         if pipeline == '':
             current_dir = os.path.dirname(os.path.abspath(__file__))
             default_pipeline = os.path.join(current_dir,'.MaltPath','Malt','Pipelines','NPR_Pipeline','NPR_Pipeline_Nodes.py')
@@ -76,7 +76,14 @@ class MaltPipeline(bpy.types.PropertyGroup):
 
         setup_all_ids()
     
-    pipeline : bpy.props.StringProperty(name="Malt Pipeline", subtype='FILE_PATH', update=update_pipeline)
+    def _set_pipeline(self, value):
+        self['pipeline'] = value.replace('\\','/')
+    def _get_pipeline(self):
+        return self.get('pipeline','').replace('\\','/')
+
+    pipeline : bpy.props.StringProperty(name="Malt Pipeline", subtype='FILE_PATH', update=update_pipeline,
+        set=malt_path_setter('pipeline'), get=malt_path_getter('pipeline'))
+
     viewport_bit_depth : bpy.props.EnumProperty(items=[('8', '8', ''),('32', '32', '')], 
         name="Bit Depth (Viewport)", update=update_pipeline)
     graph_types : bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)

--- a/BlenderMalt/__init__.py
+++ b/BlenderMalt/__init__.py
@@ -44,14 +44,25 @@ class OT_MaltPrintError(bpy.types.Operator):
         context.window_manager.modal_handler_add(self)
         return {'RUNNING_MODAL'}
 
+# Always store paths in UNIX format so saved files work across OSs
+def malt_path_setter(property_name):
+    def setter(self, value):
+        self[property_name] = value.replace('\\','/')
+    return setter
+
+def malt_path_getter(property_name):
+    def getter(self):
+        return self.get(property_name,'').replace('\\','/')
+    return getter
 
 class Preferences(bpy.types.AddonPreferences):
     # this must match the addon name
     bl_idname = __package__
 
     setup_vs_code : bpy.props.BoolProperty(name="Auto setup VSCode", default=True, description="Setups a VSCode project on your .blend file folder")
-    
-    renderdoc_path : bpy.props.StringProperty(name="RenderDoc Path", subtype='FILE_PATH')
+
+    renderdoc_path : bpy.props.StringProperty(name="RenderDoc Path", subtype='FILE_PATH',
+        set=malt_path_setter('renderdoc_path'), get=malt_path_getter('renderdoc_path'))
     
     malt_library_path : bpy.props.StringProperty(name="Malt Library Path", subtype='DIR_PATH')
     

--- a/Malt/Pipeline.py
+++ b/Malt/Pipeline.py
@@ -101,6 +101,7 @@ class Pipeline(object):
         else:
             for shader_path in self.SHADER_INCLUDE_PATHS + search_paths:
                 full_path = os.path.join(shader_path, path)
+                full_path = full_path.replace('\\', '/')
                 if os.path.exists(full_path):
                     return full_path
         return None

--- a/Malt/Pipeline.py
+++ b/Malt/Pipeline.py
@@ -101,7 +101,6 @@ class Pipeline(object):
         else:
             for shader_path in self.SHADER_INCLUDE_PATHS + search_paths:
                 full_path = os.path.join(shader_path, path)
-                full_path = full_path.replace('\\', '/')
                 if os.path.exists(full_path):
                     return full_path
         return None


### PR DESCRIPTION
Hello!

When I open a blend file saved in Windows in Linux, it gives me an error because it can't read the Malt path.
This PR is to fix it.
The Linux path can be read in Windows, so I made it a Linux path and then read it.

I have confirmed that files created in Windows can be rendered in Linux without any problems.