### PR TITLE
Print ipc error code

### DIFF
--- a/Bridge/Client_API.py
+++ b/Bridge/Client_API.py
@@ -161,7 +161,10 @@ class Bridge(object):
         if reuse_buffer is None:
             min_size = 1024*1024
             new_size = max(requested_size * 2, min_size)
-            reuse_buffer = ipc.SharedBuffer(ctypes.c_byte, new_size)
+            try:
+                reuse_buffer = ipc.SharedBuffer(ctypes.c_byte, new_size)
+            except OSError as e:
+                log.error(e)
             self.shared_buffers.append(reuse_buffer)
         
         if reuse_buffer:

--- a/Bridge/Client_API.py
+++ b/Bridge/Client_API.py
@@ -161,10 +161,7 @@ class Bridge(object):
         if reuse_buffer is None:
             min_size = 1024*1024
             new_size = max(requested_size * 2, min_size)
-            try:
-                reuse_buffer = ipc.SharedBuffer(ctypes.c_byte, new_size)
-            except OSError as e:
-                log.error(e)
+            reuse_buffer = ipc.SharedBuffer(ctypes.c_byte, new_size)
             self.shared_buffers.append(reuse_buffer)
         
         if reuse_buffer:

--- a/Bridge/ipc/__init__.py
+++ b/Bridge/ipc/__init__.py
@@ -17,13 +17,21 @@ class C_SharedMemory(ctypes.Structure):
         ('int', ctypes.c_int),
     ]
 
+def errcheck(ret, func, args):
+    if ret != 0:
+        import os
+        raise OSError(ret, os.strerror(ret))
+    return ret
+
 create_shared_memory = Ipc['create_shared_memory']
-create_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t]
-create_shared_memory.restype = C_SharedMemory
+create_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.POINTER(C_SharedMemory)]
+create_shared_memory.restype = ctypes.c_int
+create_shared_memory.errcheck = errcheck
 
 open_shared_memory = Ipc['open_shared_memory']
-open_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t]
-open_shared_memory.restype = C_SharedMemory
+open_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.POINTER(C_SharedMemory)]
+open_shared_memory.restype = ctypes.c_int
+open_shared_memory.errcheck = errcheck
 
 close_shared_memory = Ipc['close_shared_memory']
 close_shared_memory.argtypes = [C_SharedMemory, ctypes.c_bool]
@@ -56,8 +64,10 @@ class SharedBuffer():
         self._ctype = ctype
         self._size = size
         self.id = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
-        self._buffer = create_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes())
-        self._release_flag = create_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool))
+        self._buffer = C_SharedMemory()
+        create_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes(), ctypes.byref(self._buffer))
+        self._release_flag = C_SharedMemory()
+        create_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool), ctypes.byref(self._release_flag))
         ctypes.c_bool.from_address(self._release_flag.data).value = False
         self._is_owner = True
     
@@ -72,8 +82,10 @@ class SharedBuffer():
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._is_owner = False
-        self._buffer = open_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes())
-        self._release_flag = open_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool))
+        self._buffer = C_SharedMemory()
+        open_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes(), ctypes.byref(self._buffer))
+        self._release_flag = C_SharedMemory()
+        open_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool), ctypes.byref(self._release_flag))
     
     def size_in_bytes(self):
         return ctypes.sizeof(self._ctype) * self._size

--- a/Bridge/ipc/ipc.c
+++ b/Bridge/ipc/ipc.c
@@ -9,27 +9,25 @@
 #define IPC_IMPLEMENTATION
 #include "ipc.h"
 
-EXPORT ipc_sharedmemory create_shared_memory(char* name, size_t size)
+EXPORT int create_shared_memory(char* name, size_t size, ipc_sharedmemory* mem)
 {
-    ipc_sharedmemory mem = {0};
-    ipc_mem_init(&mem, name, size);
-    ipc_mem_create(&mem);
-
-    return mem;
+    ipc_mem_init(mem, name, size);
+    if (ipc_mem_create(mem) != 0) {
+        return errno;
+    }
+    return 0;
 }
 
-EXPORT ipc_sharedmemory open_shared_memory(char* name, size_t size)
+EXPORT int open_shared_memory(char* name, size_t size, ipc_sharedmemory* mem)
 {
-    ipc_sharedmemory mem = {0};
-    ipc_mem_init(&mem, name, size);
-    ipc_mem_open_existing(&mem);
-    
-    return mem;
+    ipc_mem_init(mem, name, size);
+    if (ipc_mem_open_existing(mem) != 0) {
+        return errno;
+    }
+    return 0;
 }
 
 EXPORT void close_shared_memory(ipc_sharedmemory  mem, bool release)
 {
     ipc_mem_close(&mem, release);
 }
-
-


### PR DESCRIPTION
When I tried to render the entire animation on Linux (Ubuntu), it failed with an error in the middle.
To investigate the error, I first created a PR to locate and log the error.

This PR only goes as far as producing the log, and another PR is issued to solve the problem.

If ipc.c has an error, we get the error number and return.
If this error number is non-zero, it will output an error log.

Now, for example, when rendering fails in Ubuntu, the following error log will be output.

<details>
<summary>logfile</summary>

```
...
Malt > GL_RGBA32F GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA32F GL_READ_PIXELS_TYPE: GL_FLOAT
Malt > GL_RGBA32F GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA32F GL_TEXTURE_IMAGE_TYPE: GL_FLOAT
Malt > --------------------------------------------------------------------------------
Malt > INIT PIPELINE: /home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Malt/Pipelines/NPR_Pipeline/NPR_Pipeline_Nodes.py
Blender > Blender 2.93.6 b'master' b'c842a90e2fa1'
Blender > [Errno 24] Too many open files
```
</details>