### PR TITLE
Fix linux render animation file descriptor error

### DIFF
--- a/Bridge/Client_API.py
+++ b/Bridge/Client_API.py
@@ -161,7 +161,10 @@ class Bridge(object):
         if reuse_buffer is None:
             min_size = 1024*1024
             new_size = max(requested_size * 2, min_size)
-            reuse_buffer = ipc.SharedBuffer(ctypes.c_byte, new_size)
+            try:
+                reuse_buffer = ipc.SharedBuffer(ctypes.c_byte, new_size)
+            except OSError as e:
+                log.error(e)
             self.shared_buffers.append(reuse_buffer)
         
         if reuse_buffer:

--- a/Bridge/ipc/__init__.py
+++ b/Bridge/ipc/__init__.py
@@ -17,13 +17,21 @@ class C_SharedMemory(ctypes.Structure):
         ('int', ctypes.c_int),
     ]
 
+def errcheck(ret, func, args):
+    if ret != 0:
+        import os
+        raise OSError(ret, os.strerror(ret))
+    return ret
+
 create_shared_memory = Ipc['create_shared_memory']
-create_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t]
-create_shared_memory.restype = C_SharedMemory
+create_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.POINTER(C_SharedMemory)]
+create_shared_memory.restype = ctypes.c_int
+create_shared_memory.errcheck = errcheck
 
 open_shared_memory = Ipc['open_shared_memory']
-open_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t]
-open_shared_memory.restype = C_SharedMemory
+open_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.POINTER(C_SharedMemory)]
+open_shared_memory.restype = ctypes.c_int
+open_shared_memory.errcheck = errcheck
 
 close_shared_memory = Ipc['close_shared_memory']
 close_shared_memory.argtypes = [C_SharedMemory, ctypes.c_bool]
@@ -56,8 +64,10 @@ class SharedBuffer():
         self._ctype = ctype
         self._size = size
         self.id = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
-        self._buffer = create_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes())
-        self._release_flag = create_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool))
+        self._buffer = C_SharedMemory()
+        create_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes(), ctypes.byref(self._buffer))
+        self._release_flag = C_SharedMemory()
+        create_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool), ctypes.byref(self._release_flag))
         ctypes.c_bool.from_address(self._release_flag.data).value = False
         self._is_owner = True
     
@@ -72,8 +82,10 @@ class SharedBuffer():
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._is_owner = False
-        self._buffer = open_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes())
-        self._release_flag = open_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool))
+        self._buffer = C_SharedMemory()
+        open_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes(), ctypes.byref(self._buffer))
+        self._release_flag = C_SharedMemory()
+        open_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool), ctypes.byref(self._release_flag))
     
     def size_in_bytes(self):
         return ctypes.sizeof(self._ctype) * self._size

--- a/Bridge/ipc/ipc.c
+++ b/Bridge/ipc/ipc.c
@@ -9,27 +9,25 @@
 #define IPC_IMPLEMENTATION
 #include "ipc.h"
 
-EXPORT ipc_sharedmemory create_shared_memory(char* name, size_t size)
+EXPORT int create_shared_memory(char* name, size_t size, ipc_sharedmemory* mem)
 {
-    ipc_sharedmemory mem = {0};
-    ipc_mem_init(&mem, name, size);
-    ipc_mem_create(&mem);
-
-    return mem;
+    ipc_mem_init(mem, name, size);
+    if (ipc_mem_create(mem) != 0) {
+        return errno;
+    }
+    return 0;
 }
 
-EXPORT ipc_sharedmemory open_shared_memory(char* name, size_t size)
+EXPORT int open_shared_memory(char* name, size_t size, ipc_sharedmemory* mem)
 {
-    ipc_sharedmemory mem = {0};
-    ipc_mem_init(&mem, name, size);
-    ipc_mem_open_existing(&mem);
-    
-    return mem;
+    ipc_mem_init(mem, name, size);
+    if (ipc_mem_open_existing(mem) != 0) {
+        return errno;
+    }
+    return 0;
 }
 
 EXPORT void close_shared_memory(ipc_sharedmemory  mem, bool release)
 {
     ipc_mem_close(&mem, release);
 }
-
-

--- a/Bridge/ipc/ipc.h
+++ b/Bridge/ipc/ipc.h
@@ -323,6 +323,9 @@ int ipc_mem_open_existing(ipc_sharedmemory *mem)
     if (!mem->data)
         return -1;
 
+    // file descriptor can close after mmap
+    close(mem->fd);
+
     return 0;
 }
 
@@ -343,6 +346,9 @@ int ipc_mem_create(ipc_sharedmemory *mem)
     if (!mem->data)
         return -1;
 
+    // file descriptor can close after mmap
+    close(mem->fd);
+
     return 0;
 }
 
@@ -351,7 +357,7 @@ void ipc_mem_close(ipc_sharedmemory *mem, bool unlink)
     if (mem->data != NULL)
     {
         munmap(mem->data, mem->size);
-        close(mem->fd);
+        // close(mem->fd);
         if (unlink) shm_unlink(mem->name);
     }
     IPC_FREE(mem->name);


### PR DESCRIPTION
You need to look at https://github.com/bnpr/Malt/pull/174 before this PR.

---

I tried to render the entire animation on Linux (Ubuntu), but it failed with an error in the middle.
Here is the blend file.

[blendfile.zip](https://github.com/bnpr/Malt/files/7587757/blendfile.zip)

Here is the terminal log of the execution.

<details>
<summary>terminal</summary>

```
Blender 2.93.6 (hash c842a90e2fa1 built 2021-11-17 00:44:28)
Read prefs: /home/ubuntu/.config/blender/2.93/config/userpref.blend
Read blend: /home/ubuntu/cloud-render.blend
Unable to load numpy_formathandler accelerator from OpenGL_accelerate
Saved: '/home/ubuntu/blender-render/renders/frames/00001.png'
 Time: 00:05.21 (Saving: 00:00.44)

Saved: '/home/ubuntu/blender-render/renders/frames/00002.png'
 Time: 00:01.27 (Saving: 00:00.16)

Saved: '/home/ubuntu/blender-render/renders/frames/00003.png'
 Time: 00:01.23 (Saving: 00:00.14)

Saved: '/home/ubuntu/blender-render/renders/frames/00004.png'
 Time: 00:01.26 (Saving: 00:00.16)

Saved: '/home/ubuntu/blender-render/renders/frames/00005.png'
 Time: 00:01.27 (Saving: 00:00.14)

Saved: '/home/ubuntu/blender-render/renders/frames/00006.png'
 Time: 00:01.32 (Saving: 00:00.21)

Saved: '/home/ubuntu/blender-render/renders/frames/00007.png'
 Time: 00:01.23 (Saving: 00:00.12)

Saved: '/home/ubuntu/blender-render/renders/frames/00008.png'
 Time: 00:01.22 (Saving: 00:00.11)

Saved: '/home/ubuntu/blender-render/renders/frames/00009.png'
 Time: 00:01.43 (Saving: 00:00.31)

Exception ignored in: <function SharedBuffer.__del__ at 0x7f54a53e7e50>
Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/ipc/__init__.py", line 110, in __del__
AttributeError: 'SharedBuffer' object has no attribute '_is_owner'
Exception ignored in: <function Bridge.__del__ at 0x7f54a5295670>
Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Client_API.py", line 96, in __del__
AttributeError: 'Bridge' object has no attribute 'process'
Error: Python: Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltRenderEngine.py", line 238, in render
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltRenderEngine.py", line 197, in get_scene
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltRenderEngine.py", line 122, in add_object
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltMeshes.py", line 55, in load_mesh
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltMeshes.py", line 111, in get_load_buffer
AttributeError: 'NoneType' object has no attribute 'get_shared_buffer'

location: <unknown location>:-1

Python: Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltRenderEngine.py", line 238, in render
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltRenderEngine.py", line 197, in get_scene
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltRenderEngine.py", line 122, in add_object
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltMeshes.py", line 55, in load_mesh
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/MaltMeshes.py", line 111, in get_load_buffer
AttributeError: 'NoneType' object has no attribute 'get_shared_buffer'

location: <unknown location>:-1
imb_savepng: Cannot open file for writing: '/home/ubuntu/blender-render/renders/frames/00010.png'
/home/ubuntu/blender-render/renders/frames/00010.png: Too many open files
Error: Render error (Too many open files) cannot save: '/home/ubuntu/blender-render/renders/frames/00010.png'
 Time: 00:00.07 (Saving: 00:00.01)


Blender quit
/home/ubuntu/blender-2.93.6-linux-x64/2.93/python/lib/python3.9/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 4 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '

```
</details>

Here is the log file.

<details>
<summary>malt 2021-11-23(11-26).log</summary>

```
Blender > SETUP IOCapture
Malt > DEBUG MODE: False
Malt > CONNECTIONS:
Malt > Name: PARAMS Adress: ('127.0.0.1', 46371)
Malt > Name: MESH Adress: ('127.0.0.1', 37097)
Malt > Name: MATERIAL Adress: ('127.0.0.1', 41839)
Malt > Name: SHADER REFLECTION Adress: ('127.0.0.1', 38735)
Malt > Name: TEXTURE Adress: ('127.0.0.1', 32871)
Malt > Name: GRADIENT Adress: ('127.0.0.1', 35735)
Malt > Name: RENDER Adress: ('127.0.0.1', 43829)
Malt > SYSTEM INFO
Malt > --------------------------------------------------------------------------------
Malt > PYTHON: 3.9.2 (default, Feb 25 2021, 12:19:39) 
[GCC 9.3.1 20200408 (Red Hat 9.3.1-2)]
Malt > OS: Linux-5.4.0-1059-aws-x86_64-with-glibc2.27
Malt > CPU: x86_64
Malt > OPENGL CONTEXT:
Malt > NVIDIA Corporation
Malt > Tesla T4/PCIe/SSE2
Malt > 4.1.0 NVIDIA 470.82.01
Malt > 4.10 NVIDIA via Cg compiler
Malt > GL_ARB_bindless_texture support : True
Malt > Unable to load numpy_formathandler accelerator from OpenGL_accelerate
Malt > GL_MAX_3D_TEXTURE_SIZE: 16384
Malt > GL_MAX_ARRAY_TEXTURE_LAYERS: 2048
Malt > GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS: 8
Malt > GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE: 65536
Malt > GL_MAX_CLIP_DISTANCES: 8
Malt > GL_MAX_CLIP_PLANES: 8
Malt > GL_MAX_COLOR_ATTACHMENTS: 8
Malt > GL_MAX_COLOR_TEXTURE_SAMPLES: 64
Malt > GL_MAX_COMBINED_ATOMIC_COUNTERS: 98304
Malt > GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS: 48
Malt > GL_MAX_COMBINED_CLIP_AND_CULL_DISTANCES: 8
Malt > GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS: 231424
Malt > GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS: 233472
Malt > GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS: 231424
Malt > GL_MAX_COMBINED_IMAGE_UNIFORMS: 48
Malt > GL_MAX_COMBINED_IMAGE_UNITS_AND_FRAGMENT_OUTPUTS: 16
Malt > GL_MAX_COMBINED_SHADER_OUTPUT_RESOURCES: 16
Malt > GL_MAX_COMBINED_SHADER_STORAGE_BLOCKS: 96
Malt > GL_MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS: 231424
Malt > GL_MAX_COMBINED_TESS_EVALUATION_UNIFORM_COMPONENTS: 231424
Malt > GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS: 192
Malt > GL_MAX_COMBINED_UNIFORM_BLOCKS: 84
Malt > GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS: 233472
Malt > GL_MAX_COMPUTE_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_COMPUTE_IMAGE_UNIFORMS: 8
Malt > GL_MAX_COMPUTE_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_COMPUTE_SHARED_MEMORY_SIZE: 49152
Malt > GL_MAX_COMPUTE_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_COMPUTE_UNIFORM_BLOCKS: 14
Malt > GL_MAX_COMPUTE_UNIFORM_COMPONENTS: 2048
Malt > GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS: 1024
Malt > GL_MAX_CUBE_MAP_TEXTURE_SIZE: 32768
Malt > GL_MAX_CULL_DISTANCES: 8
Malt > GL_MAX_DEBUG_GROUP_STACK_DEPTH: 64
Malt > GL_MAX_DEBUG_GROUP_STACK_DEPTH_KHR: 64
Malt > GL_MAX_DEBUG_LOGGED_MESSAGES: 128
Malt > GL_MAX_DEBUG_LOGGED_MESSAGES_KHR: 128
Malt > GL_MAX_DEBUG_MESSAGE_LENGTH: 1024
Malt > GL_MAX_DEBUG_MESSAGE_LENGTH_KHR: 1024
Malt > GL_MAX_DEPTH_TEXTURE_SAMPLES: 64
Malt > GL_MAX_DRAW_BUFFERS: 8
Malt > GL_MAX_DUAL_SOURCE_DRAW_BUFFERS: 1
Malt > GL_MAX_ELEMENTS_INDICES: 1048576
Malt > GL_MAX_ELEMENTS_VERTICES: 1048576
Malt > GL_MAX_ELEMENT_INDEX: -1
Malt > GL_MAX_EVAL_ORDER: 8
Malt > GL_MAX_FRAGMENT_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_FRAGMENT_IMAGE_UNIFORMS: 8
Malt > GL_MAX_FRAGMENT_INPUT_COMPONENTS: 128
Malt > GL_MAX_FRAGMENT_INTERPOLATION_OFFSET: 1
Malt > GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_FRAGMENT_UNIFORM_BLOCKS: 14
Malt > GL_MAX_FRAGMENT_UNIFORM_COMPONENTS: 4096
Malt > GL_MAX_FRAGMENT_UNIFORM_VECTORS: 1024
Malt > GL_MAX_FRAMEBUFFER_HEIGHT: 32768
Malt > GL_MAX_FRAMEBUFFER_LAYERS: 2048
Malt > GL_MAX_FRAMEBUFFER_SAMPLES: 64
Malt > GL_MAX_FRAMEBUFFER_WIDTH: 32768
Malt > GL_MAX_GEOMETRY_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_GEOMETRY_IMAGE_UNIFORMS: 8
Malt > GL_MAX_GEOMETRY_INPUT_COMPONENTS: 128
Malt > GL_MAX_GEOMETRY_OUTPUT_COMPONENTS: 128
Malt > GL_MAX_GEOMETRY_OUTPUT_VERTICES: 1024
Malt > GL_MAX_GEOMETRY_SHADER_INVOCATIONS: 32
Malt > GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS: 1024
Malt > GL_MAX_GEOMETRY_UNIFORM_BLOCKS: 14
Malt > GL_MAX_GEOMETRY_UNIFORM_COMPONENTS: 2048
Malt > GL_MAX_IMAGE_SAMPLES: 64
Malt > GL_MAX_IMAGE_UNITS: 8
Malt > GL_MAX_INTEGER_SAMPLES: 64
Malt > GL_MAX_LABEL_LENGTH: 256
Malt > GL_MAX_LABEL_LENGTH_KHR: 256
Malt > GL_MAX_LIGHTS: 8
Malt > GL_MAX_LIST_NESTING: 64
Malt > GL_MAX_MODELVIEW_STACK_DEPTH: 32
Malt > GL_MAX_NAME_STACK_DEPTH: 128
Malt > GL_MAX_PATCH_VERTICES: 32
Malt > GL_MAX_PIXEL_MAP_TABLE: 65536
Malt > GL_MAX_PROGRAM_TEXEL_OFFSET: 7
Malt > GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET: 31
Malt > GL_MAX_PROJECTION_STACK_DEPTH: 4
Malt > GL_MAX_RECTANGLE_TEXTURE_SIZE: 32768
Malt > GL_MAX_RENDERBUFFER_SIZE: 32768
Malt > GL_MAX_SAMPLES: 64
Malt > GL_MAX_SAMPLE_MASK_WORDS: 2
Malt > GL_MAX_SERVER_WAIT_TIMEOUT: -1
Malt > GL_MAX_SHADER_STORAGE_BLOCK_SIZE: 2147483647
Malt > GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS: 96
Malt > GL_MAX_SUBROUTINES: 1024
Malt > GL_MAX_SUBROUTINE_UNIFORM_LOCATIONS: 1024
Malt > GL_MAX_TESS_CONTROL_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_TESS_CONTROL_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_TESS_CONTROL_IMAGE_UNIFORMS: 8
Malt > GL_MAX_TESS_CONTROL_INPUT_COMPONENTS: 128
Malt > GL_MAX_TESS_CONTROL_OUTPUT_COMPONENTS: 128
Malt > GL_MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_TESS_CONTROL_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_TESS_CONTROL_TOTAL_OUTPUT_COMPONENTS: 4216
Malt > GL_MAX_TESS_CONTROL_UNIFORM_BLOCKS: 14
Malt > GL_MAX_TESS_CONTROL_UNIFORM_COMPONENTS: 2048
Malt > GL_MAX_TESS_EVALUATION_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_TESS_EVALUATION_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_TESS_EVALUATION_IMAGE_UNIFORMS: 8
Malt > GL_MAX_TESS_EVALUATION_INPUT_COMPONENTS: 128
Malt > GL_MAX_TESS_EVALUATION_OUTPUT_COMPONENTS: 128
Malt > GL_MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_TESS_EVALUATION_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_TESS_EVALUATION_UNIFORM_BLOCKS: 14
Malt > GL_MAX_TESS_EVALUATION_UNIFORM_COMPONENTS: 2048
Malt > GL_MAX_TESS_GEN_LEVEL: 64
Malt > GL_MAX_TESS_PATCH_COMPONENTS: 120
Malt > GL_MAX_TEXTURE_BUFFER_SIZE: 134217728
Malt > GL_MAX_TEXTURE_COORDS: 8
Malt > GL_MAX_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_TEXTURE_LOD_BIAS: 15
Malt > GL_MAX_TEXTURE_MAX_ANISOTROPY: 16
Malt > GL_MAX_TEXTURE_SIZE: 32768
Malt > GL_MAX_TEXTURE_STACK_DEPTH: 10
Malt > GL_MAX_TEXTURE_UNITS: 4
Malt > GL_MAX_TRANSFORM_FEEDBACK_BUFFERS: 4
Malt > GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS: 128
Malt > GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS: 4
Malt > GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS: 4
Malt > GL_MAX_UNIFORM_BLOCK_SIZE: 65536
Malt > GL_MAX_UNIFORM_BUFFER_BINDINGS: 84
Malt > GL_MAX_UNIFORM_LOCATIONS: 65536
Malt > GL_MAX_VARYING_COMPONENTS: 124
Malt > GL_MAX_VARYING_FLOATS: 124
Malt > GL_MAX_VARYING_VECTORS: 31
Malt > GL_MAX_VERTEX_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_VERTEX_ATTRIBS: 16
Malt > GL_MAX_VERTEX_ATTRIB_BINDINGS: 16
Malt > GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET: 2047
Malt > GL_MAX_VERTEX_IMAGE_UNIFORMS: 8
Malt > GL_MAX_VERTEX_OUTPUT_COMPONENTS: 128
Malt > GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_VERTEX_STREAMS: 4
Malt > GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_VERTEX_UNIFORM_BLOCKS: 14
Malt > GL_MAX_VERTEX_UNIFORM_COMPONENTS: 4096
Malt > GL_MAX_VERTEX_UNIFORM_VECTORS: 1024
Malt > GL_MAX_VIEWPORTS: 16
Malt > GL_MAX_VIEWPORT_DIMS: [32768 32768]
Malt > GL_RGB8 GL_READ_PIXELS: GL_ZERO
Malt > GL_RGB8 GL_READ_PIXELS_FORMAT: GL_ZERO
Malt > GL_RGB8 GL_READ_PIXELS_TYPE: GL_UNSIGNED_BYTE
Malt > GL_RGB8 GL_TEXTURE_IMAGE_FORMAT: GL_ZERO
Malt > GL_RGB8 GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_BYTE
Malt > GL_RGBA8 GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_RGBA8 GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA8 GL_READ_PIXELS_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_RGBA8 GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA8 GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_RGBA GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_RGBA GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA GL_READ_PIXELS_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_RGBA GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_SRGB GL_READ_PIXELS: GL_ZERO
Malt > GL_SRGB GL_READ_PIXELS_FORMAT: GL_ZERO
Malt > GL_SRGB GL_READ_PIXELS_TYPE: GL_UNSIGNED_BYTE
Malt > GL_SRGB GL_TEXTURE_IMAGE_FORMAT: GL_ZERO
Malt > GL_SRGB GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_BYTE
Malt > GL_SRGB_ALPHA GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_SRGB_ALPHA GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_SRGB_ALPHA GL_READ_PIXELS_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_SRGB_ALPHA GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_SRGB_ALPHA GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_RGB16F GL_READ_PIXELS: GL_ZERO
Malt > GL_RGB16F GL_READ_PIXELS_FORMAT: GL_ZERO
Malt > GL_RGB16F GL_READ_PIXELS_TYPE: GL_HALF_FLOAT
Malt > GL_RGB16F GL_TEXTURE_IMAGE_FORMAT: GL_ZERO
Malt > GL_RGB16F GL_TEXTURE_IMAGE_TYPE: GL_HALF_FLOAT
Malt > GL_RGBA16F GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_RGBA16F GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA16F GL_READ_PIXELS_TYPE: GL_HALF_FLOAT
Malt > GL_RGBA16F GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA16F GL_TEXTURE_IMAGE_TYPE: GL_HALF_FLOAT
Malt > GL_RGB32F GL_READ_PIXELS: GL_ZERO
Malt > GL_RGB32F GL_READ_PIXELS_FORMAT: GL_ZERO
Malt > GL_RGB32F GL_READ_PIXELS_TYPE: GL_FLOAT
Malt > GL_RGB32F GL_TEXTURE_IMAGE_FORMAT: GL_ZERO
Malt > GL_RGB32F GL_TEXTURE_IMAGE_TYPE: GL_FLOAT
Malt > GL_RGBA32F GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_RGBA32F GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA32F GL_READ_PIXELS_TYPE: GL_FLOAT
Malt > GL_RGBA32F GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA32F GL_TEXTURE_IMAGE_TYPE: GL_FLOAT
Malt > --------------------------------------------------------------------------------
Malt > INIT PIPELINE: /home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Malt/Pipelines/NPR_Pipeline/NPR_Pipeline_Nodes.py
Blender > Blender 2.93.6 b'master' b'c842a90e2fa1'
Blender > [Errno 24] Too many open files
Blender > Exception ignored in: 
Blender > <function SharedBuffer.__del__ at 0x7f54a53e7e50>
Blender > 

Blender > Traceback (most recent call last):

Blender >   File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/ipc/__init__.py", line 110, in __del__

Blender > AttributeError
Blender > : 
Blender > 'SharedBuffer' object has no attribute '_is_owner'
Blender > 

Blender > Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Client_API.py", line 11, in result
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Client_API.py", line 155, in get_shared_buffer
AttributeError: 'NoneType' object has no attribute '_release_flag'

Blender > Exception ignored in: 
Blender > <function Bridge.__del__ at 0x7f54a5295670>
Blender > 

Blender > Traceback (most recent call last):

Blender >   File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Client_API.py", line 96, in __del__

Blender > AttributeError
Blender > : 
Blender > 'Bridge' object has no attribute 'process'
Blender > 


```
</details>

You can see the error "Too many open files".
This error comes up when the file descriptor cannot be opened.
The problem is that there are not enough file descriptors.

I wrote the code to close the file descriptor immediately after the mmap because it is safe to do so.
c7c928c6f1159b7e1cea1047779ff4e800da9c8d

The rendering is now done without any problem.

---

I read the source code and wrote what I understood in the comments.
eac1fd9da804e0909dadcb9a6f93cd61d9b0e2ee
If this is wrong, please delete it.

If the comment is correct, then `close_shared_memory` should be called at the time when the SharedBuffer of the msg sent to Server.py is `__del__` and the fd is released.
If `__del__` is called correctly, there should be no leakage of file descriptors, so I should be able to render without running out of file descriptors.
However, depending on whether there are still references or circular references, `close_shared_memory` may not be called as expected in SharedBuffer's `__del__`.

In my opinion, it is better to explicitly write the open process in a way other than `__del__` because it is difficult to know when `__del__` in Python is called.
If the next frame is rendered with a reference left by mistake, `__del__` will not be called correctly and resources will be eaten up.

This PR solves the problem of file descriptor exhaustion, but if `__del__` is not being called as expected, I think we need to investigate the cause separately and fix it.