### PR TITLE
Fix mesh recv timing error

### DIFF
--- a/Bridge/Client_API.py
+++ b/Bridge/Client_API.py
@@ -161,7 +161,10 @@ class Bridge(object):
         if reuse_buffer is None:
             min_size = 1024*1024
             new_size = max(requested_size * 2, min_size)
-            reuse_buffer = ipc.SharedBuffer(ctypes.c_byte, new_size)
+            try:
+                reuse_buffer = ipc.SharedBuffer(ctypes.c_byte, new_size)
+            except OSError as e:
+                log.error(e)
             self.shared_buffers.append(reuse_buffer)
         
         if reuse_buffer:

--- a/Bridge/ipc/__init__.py
+++ b/Bridge/ipc/__init__.py
@@ -17,13 +17,21 @@ class C_SharedMemory(ctypes.Structure):
         ('int', ctypes.c_int),
     ]
 
+def errcheck(ret, func, args):
+    if ret != 0:
+        import os
+        raise OSError(ret, os.strerror(ret))
+    return ret
+
 create_shared_memory = Ipc['create_shared_memory']
-create_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t]
-create_shared_memory.restype = C_SharedMemory
+create_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.POINTER(C_SharedMemory)]
+create_shared_memory.restype = ctypes.c_int
+create_shared_memory.errcheck = errcheck
 
 open_shared_memory = Ipc['open_shared_memory']
-open_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t]
-open_shared_memory.restype = C_SharedMemory
+open_shared_memory.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.POINTER(C_SharedMemory)]
+open_shared_memory.restype = ctypes.c_int
+open_shared_memory.errcheck = errcheck
 
 close_shared_memory = Ipc['close_shared_memory']
 close_shared_memory.argtypes = [C_SharedMemory, ctypes.c_bool]
@@ -56,8 +64,10 @@ class SharedBuffer():
         self._ctype = ctype
         self._size = size
         self.id = ''.join(random.choices(string.ascii_letters + string.digits, k=16))
-        self._buffer = create_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes())
-        self._release_flag = create_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool))
+        self._buffer = C_SharedMemory()
+        create_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes(), ctypes.byref(self._buffer))
+        self._release_flag = C_SharedMemory()
+        create_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool), ctypes.byref(self._release_flag))
         ctypes.c_bool.from_address(self._release_flag.data).value = False
         self._is_owner = True
     
@@ -72,8 +82,10 @@ class SharedBuffer():
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._is_owner = False
-        self._buffer = open_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes())
-        self._release_flag = open_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool))
+        self._buffer = C_SharedMemory()
+        open_shared_memory(('MALT_SHARED_'+self.id).encode('ascii'), self.size_in_bytes(), ctypes.byref(self._buffer))
+        self._release_flag = C_SharedMemory()
+        open_shared_memory(('MALT_FLAG_'+self.id).encode('ascii'), ctypes.sizeof(ctypes.c_bool), ctypes.byref(self._release_flag))
     
     def size_in_bytes(self):
         return ctypes.sizeof(self._ctype) * self._size

--- a/Bridge/ipc/ipc.c
+++ b/Bridge/ipc/ipc.c
@@ -9,27 +9,25 @@
 #define IPC_IMPLEMENTATION
 #include "ipc.h"
 
-EXPORT ipc_sharedmemory create_shared_memory(char* name, size_t size)
+EXPORT int create_shared_memory(char* name, size_t size, ipc_sharedmemory* mem)
 {
-    ipc_sharedmemory mem = {0};
-    ipc_mem_init(&mem, name, size);
-    ipc_mem_create(&mem);
-
-    return mem;
+    ipc_mem_init(mem, name, size);
+    if (ipc_mem_create(mem) != 0) {
+        return errno;
+    }
+    return 0;
 }
 
-EXPORT ipc_sharedmemory open_shared_memory(char* name, size_t size)
+EXPORT int open_shared_memory(char* name, size_t size, ipc_sharedmemory* mem)
 {
-    ipc_sharedmemory mem = {0};
-    ipc_mem_init(&mem, name, size);
-    ipc_mem_open_existing(&mem);
-    
-    return mem;
+    ipc_mem_init(mem, name, size);
+    if (ipc_mem_open_existing(mem) != 0) {
+        return errno;
+    }
+    return 0;
 }
 
 EXPORT void close_shared_memory(ipc_sharedmemory  mem, bool release)
 {
     ipc_mem_close(&mem, release);
 }
-
-

--- a/Bridge/ipc/ipc.h
+++ b/Bridge/ipc/ipc.h
@@ -323,6 +323,9 @@ int ipc_mem_open_existing(ipc_sharedmemory *mem)
     if (!mem->data)
         return -1;
 
+    // file descriptor can close after mmap
+    close(mem->fd);
+
     return 0;
 }
 
@@ -343,6 +346,9 @@ int ipc_mem_create(ipc_sharedmemory *mem)
     if (!mem->data)
         return -1;
 
+    // file descriptor can close after mmap
+    close(mem->fd);
+
     return 0;
 }
 
@@ -351,7 +357,7 @@ void ipc_mem_close(ipc_sharedmemory *mem, bool unlink)
     if (mem->data != NULL)
     {
         munmap(mem->data, mem->size);
-        close(mem->fd);
+        // close(mem->fd);
         if (unlink) shm_unlink(mem->name);
     }
     IPC_FREE(mem->name);


### PR DESCRIPTION
base branch: https://github.com/bnpr/Malt/pull/175

---

When I tried to render, I got the following error.

```
Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 392, in main
    viewports[viewport_id].setup(new_buffers, resolution, scene, scene_update, renderdoc_capture)
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 189, in setup
    submesh.mesh = Bridge.Mesh.MESHES[submesh.mesh][i]
KeyError: '___F12___MESH_Cube.010'

Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 404, in main
    has_finished = v.render()
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 210, in render
    result = self.pipeline.render(self.resolution, self.scene, self.is_final_render, self.is_new_frame)
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Malt/Pipeline.py", line 305, in render
    self.result = self.do_render(resolution, scene, is_final_render, is_new_frame)
  File "/home/ubuntu/MyPipeline/CustomPipeline.py", line 259, in do_render
    if self.sampling_grid_size != scene.world_parameters["Samples.Grid Size"]:
AttributeError: 'NoneType' object has no attribute 'world_parameters'

(Repeated 1+ times)
(Repeated 10+ times)
(Repeated 100+ times)
(Repeated 1000+ times)
(Repeated 10000+ times)
(Repeated 100000+ times)
```

The log is here.

<details>
<summary>malt 2021-11-23(14-50).log</summary>

```
Blender > SETUP IOCapture
Malt > DEBUG MODE: False
Malt > CONNECTIONS:
Malt > Name: PARAMS Adress: ('127.0.0.1', 43673)
Malt > Name: MESH Adress: ('127.0.0.1', 34601)
Malt > Name: MATERIAL Adress: ('127.0.0.1', 43939)
Malt > Name: SHADER REFLECTION Adress: ('127.0.0.1', 38507)
Malt > Name: TEXTURE Adress: ('127.0.0.1', 33759)
Malt > Name: GRADIENT Adress: ('127.0.0.1', 45869)
Malt > Name: RENDER Adress: ('127.0.0.1', 40893)
Malt > SYSTEM INFO
Malt > --------------------------------------------------------------------------------
Malt > PYTHON: 3.9.2 (default, Feb 25 2021, 12:19:39) 
[GCC 9.3.1 20200408 (Red Hat 9.3.1-2)]
Malt > OS: Linux-5.4.0-1059-aws-x86_64-with-glibc2.27
Malt > CPU: x86_64
Malt > OPENGL CONTEXT:
Malt > NVIDIA Corporation
Malt > Tesla T4/PCIe/SSE2
Malt > 4.1.0 NVIDIA 470.82.01
Malt > 4.10 NVIDIA via Cg compiler
Malt > GL_ARB_bindless_texture support : True
Malt > Unable to load numpy_formathandler accelerator from OpenGL_accelerate
Malt > GL_MAX_3D_TEXTURE_SIZE: 16384
Malt > GL_MAX_ARRAY_TEXTURE_LAYERS: 2048
Malt > GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS: 8
Malt > GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE: 65536
Malt > GL_MAX_CLIP_DISTANCES: 8
Malt > GL_MAX_CLIP_PLANES: 8
Malt > GL_MAX_COLOR_ATTACHMENTS: 8
Malt > GL_MAX_COLOR_TEXTURE_SAMPLES: 64
Malt > GL_MAX_COMBINED_ATOMIC_COUNTERS: 98304
Malt > GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS: 48
Malt > GL_MAX_COMBINED_CLIP_AND_CULL_DISTANCES: 8
Malt > GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS: 231424
Malt > GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS: 233472
Malt > GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS: 231424
Malt > GL_MAX_COMBINED_IMAGE_UNIFORMS: 48
Malt > GL_MAX_COMBINED_IMAGE_UNITS_AND_FRAGMENT_OUTPUTS: 16
Malt > GL_MAX_COMBINED_SHADER_OUTPUT_RESOURCES: 16
Malt > GL_MAX_COMBINED_SHADER_STORAGE_BLOCKS: 96
Malt > GL_MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS: 231424
Malt > GL_MAX_COMBINED_TESS_EVALUATION_UNIFORM_COMPONENTS: 231424
Malt > GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS: 192
Malt > GL_MAX_COMBINED_UNIFORM_BLOCKS: 84
Malt > GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS: 233472
Malt > GL_MAX_COMPUTE_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_COMPUTE_IMAGE_UNIFORMS: 8
Malt > GL_MAX_COMPUTE_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_COMPUTE_SHARED_MEMORY_SIZE: 49152
Malt > GL_MAX_COMPUTE_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_COMPUTE_UNIFORM_BLOCKS: 14
Malt > GL_MAX_COMPUTE_UNIFORM_COMPONENTS: 2048
Malt > GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS: 1024
Malt > GL_MAX_CUBE_MAP_TEXTURE_SIZE: 32768
Malt > GL_MAX_CULL_DISTANCES: 8
Malt > GL_MAX_DEBUG_GROUP_STACK_DEPTH: 64
Malt > GL_MAX_DEBUG_GROUP_STACK_DEPTH_KHR: 64
Malt > GL_MAX_DEBUG_LOGGED_MESSAGES: 128
Malt > GL_MAX_DEBUG_LOGGED_MESSAGES_KHR: 128
Malt > GL_MAX_DEBUG_MESSAGE_LENGTH: 1024
Malt > GL_MAX_DEBUG_MESSAGE_LENGTH_KHR: 1024
Malt > GL_MAX_DEPTH_TEXTURE_SAMPLES: 64
Malt > GL_MAX_DRAW_BUFFERS: 8
Malt > GL_MAX_DUAL_SOURCE_DRAW_BUFFERS: 1
Malt > GL_MAX_ELEMENTS_INDICES: 1048576
Malt > GL_MAX_ELEMENTS_VERTICES: 1048576
Malt > GL_MAX_ELEMENT_INDEX: -1
Malt > GL_MAX_EVAL_ORDER: 8
Malt > GL_MAX_FRAGMENT_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_FRAGMENT_IMAGE_UNIFORMS: 8
Malt > GL_MAX_FRAGMENT_INPUT_COMPONENTS: 128
Malt > GL_MAX_FRAGMENT_INTERPOLATION_OFFSET: 1
Malt > GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_FRAGMENT_UNIFORM_BLOCKS: 14
Malt > GL_MAX_FRAGMENT_UNIFORM_COMPONENTS: 4096
Malt > GL_MAX_FRAGMENT_UNIFORM_VECTORS: 1024
Malt > GL_MAX_FRAMEBUFFER_HEIGHT: 32768
Malt > GL_MAX_FRAMEBUFFER_LAYERS: 2048
Malt > GL_MAX_FRAMEBUFFER_SAMPLES: 64
Malt > GL_MAX_FRAMEBUFFER_WIDTH: 32768
Malt > GL_MAX_GEOMETRY_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_GEOMETRY_IMAGE_UNIFORMS: 8
Malt > GL_MAX_GEOMETRY_INPUT_COMPONENTS: 128
Malt > GL_MAX_GEOMETRY_OUTPUT_COMPONENTS: 128
Malt > GL_MAX_GEOMETRY_OUTPUT_VERTICES: 1024
Malt > GL_MAX_GEOMETRY_SHADER_INVOCATIONS: 32
Malt > GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS: 1024
Malt > GL_MAX_GEOMETRY_UNIFORM_BLOCKS: 14
Malt > GL_MAX_GEOMETRY_UNIFORM_COMPONENTS: 2048
Malt > GL_MAX_IMAGE_SAMPLES: 64
Malt > GL_MAX_IMAGE_UNITS: 8
Malt > GL_MAX_INTEGER_SAMPLES: 64
Malt > GL_MAX_LABEL_LENGTH: 256
Malt > GL_MAX_LABEL_LENGTH_KHR: 256
Malt > GL_MAX_LIGHTS: 8
Malt > GL_MAX_LIST_NESTING: 64
Malt > GL_MAX_MODELVIEW_STACK_DEPTH: 32
Malt > GL_MAX_NAME_STACK_DEPTH: 128
Malt > GL_MAX_PATCH_VERTICES: 32
Malt > GL_MAX_PIXEL_MAP_TABLE: 65536
Malt > GL_MAX_PROGRAM_TEXEL_OFFSET: 7
Malt > GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET: 31
Malt > GL_MAX_PROJECTION_STACK_DEPTH: 4
Malt > GL_MAX_RECTANGLE_TEXTURE_SIZE: 32768
Malt > GL_MAX_RENDERBUFFER_SIZE: 32768
Malt > GL_MAX_SAMPLES: 64
Malt > GL_MAX_SAMPLE_MASK_WORDS: 2
Malt > GL_MAX_SERVER_WAIT_TIMEOUT: -1
Malt > GL_MAX_SHADER_STORAGE_BLOCK_SIZE: 2147483647
Malt > GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS: 96
Malt > GL_MAX_SUBROUTINES: 1024
Malt > GL_MAX_SUBROUTINE_UNIFORM_LOCATIONS: 1024
Malt > GL_MAX_TESS_CONTROL_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_TESS_CONTROL_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_TESS_CONTROL_IMAGE_UNIFORMS: 8
Malt > GL_MAX_TESS_CONTROL_INPUT_COMPONENTS: 128
Malt > GL_MAX_TESS_CONTROL_OUTPUT_COMPONENTS: 128
Malt > GL_MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_TESS_CONTROL_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_TESS_CONTROL_TOTAL_OUTPUT_COMPONENTS: 4216
Malt > GL_MAX_TESS_CONTROL_UNIFORM_BLOCKS: 14
Malt > GL_MAX_TESS_CONTROL_UNIFORM_COMPONENTS: 2048
Malt > GL_MAX_TESS_EVALUATION_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_TESS_EVALUATION_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_TESS_EVALUATION_IMAGE_UNIFORMS: 8
Malt > GL_MAX_TESS_EVALUATION_INPUT_COMPONENTS: 128
Malt > GL_MAX_TESS_EVALUATION_OUTPUT_COMPONENTS: 128
Malt > GL_MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_TESS_EVALUATION_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_TESS_EVALUATION_UNIFORM_BLOCKS: 14
Malt > GL_MAX_TESS_EVALUATION_UNIFORM_COMPONENTS: 2048
Malt > GL_MAX_TESS_GEN_LEVEL: 64
Malt > GL_MAX_TESS_PATCH_COMPONENTS: 120
Malt > GL_MAX_TEXTURE_BUFFER_SIZE: 134217728
Malt > GL_MAX_TEXTURE_COORDS: 8
Malt > GL_MAX_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_TEXTURE_LOD_BIAS: 15
Malt > GL_MAX_TEXTURE_MAX_ANISOTROPY: 16
Malt > GL_MAX_TEXTURE_SIZE: 32768
Malt > GL_MAX_TEXTURE_STACK_DEPTH: 10
Malt > GL_MAX_TEXTURE_UNITS: 4
Malt > GL_MAX_TRANSFORM_FEEDBACK_BUFFERS: 4
Malt > GL_MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS: 128
Malt > GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS: 4
Malt > GL_MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS: 4
Malt > GL_MAX_UNIFORM_BLOCK_SIZE: 65536
Malt > GL_MAX_UNIFORM_BUFFER_BINDINGS: 84
Malt > GL_MAX_UNIFORM_LOCATIONS: 65536
Malt > GL_MAX_VARYING_COMPONENTS: 124
Malt > GL_MAX_VARYING_FLOATS: 124
Malt > GL_MAX_VARYING_VECTORS: 31
Malt > GL_MAX_VERTEX_ATOMIC_COUNTERS: 16384
Malt > GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS: 8
Malt > GL_MAX_VERTEX_ATTRIBS: 16
Malt > GL_MAX_VERTEX_ATTRIB_BINDINGS: 16
Malt > GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET: 2047
Malt > GL_MAX_VERTEX_IMAGE_UNIFORMS: 8
Malt > GL_MAX_VERTEX_OUTPUT_COMPONENTS: 128
Malt > GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS: 16
Malt > GL_MAX_VERTEX_STREAMS: 4
Malt > GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS: 32
Malt > GL_MAX_VERTEX_UNIFORM_BLOCKS: 14
Malt > GL_MAX_VERTEX_UNIFORM_COMPONENTS: 4096
Malt > GL_MAX_VERTEX_UNIFORM_VECTORS: 1024
Malt > GL_MAX_VIEWPORTS: 16
Malt > GL_MAX_VIEWPORT_DIMS: [32768 32768]
Malt > GL_RGB8 GL_READ_PIXELS: GL_ZERO
Malt > GL_RGB8 GL_READ_PIXELS_FORMAT: GL_ZERO
Malt > GL_RGB8 GL_READ_PIXELS_TYPE: GL_UNSIGNED_BYTE
Malt > GL_RGB8 GL_TEXTURE_IMAGE_FORMAT: GL_ZERO
Malt > GL_RGB8 GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_BYTE
Malt > GL_RGBA8 GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_RGBA8 GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA8 GL_READ_PIXELS_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_RGBA8 GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA8 GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_RGBA GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_RGBA GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA GL_READ_PIXELS_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_RGBA GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_SRGB GL_READ_PIXELS: GL_ZERO
Malt > GL_SRGB GL_READ_PIXELS_FORMAT: GL_ZERO
Malt > GL_SRGB GL_READ_PIXELS_TYPE: GL_UNSIGNED_BYTE
Malt > GL_SRGB GL_TEXTURE_IMAGE_FORMAT: GL_ZERO
Malt > GL_SRGB GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_BYTE
Malt > GL_SRGB_ALPHA GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_SRGB_ALPHA GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_SRGB_ALPHA GL_READ_PIXELS_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_SRGB_ALPHA GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_SRGB_ALPHA GL_TEXTURE_IMAGE_TYPE: GL_UNSIGNED_INT_8_8_8_8_REV
Malt > GL_RGB16F GL_READ_PIXELS: GL_ZERO
Malt > GL_RGB16F GL_READ_PIXELS_FORMAT: GL_ZERO
Malt > GL_RGB16F GL_READ_PIXELS_TYPE: GL_HALF_FLOAT
Malt > GL_RGB16F GL_TEXTURE_IMAGE_FORMAT: GL_ZERO
Malt > GL_RGB16F GL_TEXTURE_IMAGE_TYPE: GL_HALF_FLOAT
Malt > GL_RGBA16F GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_RGBA16F GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA16F GL_READ_PIXELS_TYPE: GL_HALF_FLOAT
Malt > GL_RGBA16F GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA16F GL_TEXTURE_IMAGE_TYPE: GL_HALF_FLOAT
Malt > GL_RGB32F GL_READ_PIXELS: GL_ZERO
Malt > GL_RGB32F GL_READ_PIXELS_FORMAT: GL_ZERO
Malt > GL_RGB32F GL_READ_PIXELS_TYPE: GL_FLOAT
Malt > GL_RGB32F GL_TEXTURE_IMAGE_FORMAT: GL_ZERO
Malt > GL_RGB32F GL_TEXTURE_IMAGE_TYPE: GL_FLOAT
Malt > GL_RGBA32F GL_READ_PIXELS: GL_FULL_SUPPORT
Malt > GL_RGBA32F GL_READ_PIXELS_FORMAT: GL_RGBA
Malt > GL_RGBA32F GL_READ_PIXELS_TYPE: GL_FLOAT
Malt > GL_RGBA32F GL_TEXTURE_IMAGE_FORMAT: GL_RGBA
Malt > GL_RGBA32F GL_TEXTURE_IMAGE_TYPE: GL_FLOAT
Malt > --------------------------------------------------------------------------------
Malt > INIT PIPELINE: /home/ubuntu/MyPipeline/CustomPipeline.py
Blender > Blender 2.93.6 b'master' b'c842a90e2fa1'
Malt > Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 392, in main
    viewports[viewport_id].setup(new_buffers, resolution, scene, scene_update, renderdoc_capture)
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 189, in setup
    submesh.mesh = Bridge.Mesh.MESHES[submesh.mesh][i]
KeyError: '___F12___MESH_Cube.010'

Malt > Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 404, in main
    has_finished = v.render()
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 210, in render
    result = self.pipeline.render(self.resolution, self.scene, self.is_final_render, self.is_new_frame)
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Malt/Pipeline.py", line 305, in render
    self.result = self.do_render(resolution, scene, is_final_render, is_new_frame)
  File "/home/ubuntu/MyPipeline/CustomPipeline.py", line 259, in do_render
    if self.sampling_grid_size != scene.world_parameters["Samples.Grid Size"]:
AttributeError: 'NoneType' object has no attribute 'world_parameters'

Malt > (Repeated 1+ times)
Malt > (Repeated 10+ times)
Malt > (Repeated 100+ times)
Malt > (Repeated 1000+ times)
Malt > (Repeated 10000+ times)
Malt > (Repeated 100000+ times)
Malt > Traceback (most recent call last):
  File "/home/ubuntu/.config/blender/2.93/scripts/addons/BlenderMalt/.MaltPath/Bridge/Server.py", line 322, in main
    while connections['MATERIAL'].poll():
  File "/home/ubuntu/blender-2.93.6-linux-x64/2.93/python/lib/python3.9/multiprocessing/connection.py", line 262, in poll
    return self._poll(timeout)
  File "/home/ubuntu/blender-2.93.6-linux-x64/2.93/python/lib/python3.9/multiprocessing/connection.py", line 429, in _poll
    r = wait([self], timeout)
  File "/home/ubuntu/blender-2.93.6-linux-x64/2.93/python/lib/python3.9/multiprocessing/connection.py", line 928, in wait
    with _WaitSelector() as selector:
  File "/home/ubuntu/blender-2.93.6-linux-x64/2.93/python/lib/python3.9/selectors.py", line 200, in __enter__
    def __enter__(self):
KeyboardInterrupt


```
</details>

In Server.py, the RENDER process seems to be running before receiving all the MESHs.
The error occurs when there is not enough submesh in the viewport setup.

So, when an error occurs during the viewport setup due to a lack of submesh, I ran the MESH poll once more to receive all the meshes.

The error was resolved and I confirmed that it renders without any problems.

---

This PR is only a coping mechanism, not a fix for the root problem.

MaltMeshes.load_mesh() in add_object in MaltRenderEngine.get_scene should send the meshes all over.
After that, we do self.bridge.render() in MaltRenderEngine.
After all the Meshes are sent, the RENDER msg should be sent.
The fact that this error occurs despite this means that even if the sent data exists, the process proceeds at a time when the poll does not become True, and the error occurs because there are not enough Meshes.
This timing problem is serious, and I think it will require a major revamp to fix.

This temporary fix for PR is only a simple one, so I think it would be better to fix it fundamentally.
