### PR TITLE
clarifies From Node to Code tutorial's "After Installation" steps

### DIFF
--- a/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
+++ b/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
@@ -27,7 +27,7 @@ Now we can make changes in our shader file and as soon as we save it (*Ctrl+S*) 
 
 Note: When you save the blend file in step 1 and the *Malt* renderer is active, it will create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
 
-_Having problems with the setup? View a video of this installation/setup process in [YouTube](http://www.youtube.com/watch?v=UjsW7Ce0BKo "Malt VSCode config")_
+_Having problems with the setup?_
 <div style="position: relative; width: 100%; padding-top: 56.25%; /* 16:9 Aspect Ratio */">
  <iframe style="position: absolute; top: 0; left: 0; bottom: 0;right: 0; width:100%; height:100%; margin:0; border:0;" 
  src="https://www.youtube-nocookie.com/embed/UjsW7Ce0BKo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
+++ b/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
@@ -25,9 +25,10 @@ But we can make our lifes much easier by using a code editor.
 
 Now we can make changes in our shader file and as soon as we save it (*Ctrl+S*) Malt will reload it.
 
-Note: When you save the blend file in step 1 and the *Malt* renderer is active, it will create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
+> Note: When you save the blend file in step 1 and the *Malt* renderer is active, it will create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
 
-_Having problems with the setup?_
+#### Having problems with the setup?
+*Here is a step by step video of the setup process:*
 <div style="position: relative; width: 100%; padding-top: 56.25%; /* 16:9 Aspect Ratio */">
  <iframe style="position: absolute; top: 0; left: 0; bottom: 0;right: 0; width:100%; height:100%; margin:0; border:0;" 
  src="https://www.youtube-nocookie.com/embed/UjsW7Ce0BKo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
+++ b/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
@@ -12,23 +12,23 @@ You may be surprised by how much of your knowledge about node based programming 
 Shader files are just plain text, so any text editor works for writing them.  
 But we can make our lifes much easier by using a code editor.
 
+### Visual Studio Code
 *Malt* has built-in integration with [VSCode](https://code.visualstudio.com/download), it's free, cross-platform and open source so go ahead, download and install it!
 
-<div style="position: relative; width: 100%; padding-top: 56.25%; /* 16:9 Aspect Ratio */">
-<iframe style="position: absolute; top: 0; left: 0; bottom: 0;right: 0; width:100%; height:100%; margin:0; border:0;" 
-src="https://www.youtube-nocookie.com/embed/UjsW7Ce0BKo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
-
-After installation:
+### After installing Visual Studio Code:
 
 1. Open Blender, change the render engine to *Malt* and save the *.blend* file in a new folder.  
-(When *Malt* is active it will auto-setup a *VSCode* workspace on the same folder you save your *.blend* file)
-2. Open the folder in the OS file explorer and *Right Click > Open with Code*.
+2. Open this newly created folder in your OS file explorer and *Right Click > Open with Code*.
 3. Create a new file and save it as ```malt-tutorial.mesh.glsl```. (or any othe name, but make sure it ends in ```.mesh.glsl```)
 4. VSCode will tell you it has extensions for that file format and will ask you if you want to install them, say yes!
 5. Select the shader file as the *Shader Source* for a new material (*Material Properties* Panel).
 
 Now we can make changes in our shader file and as soon as we save it (*Ctrl+S*) Malt will reload it.
+
+Note: When you save the blend file in step 1 and *Malt* is active it will auto-create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
+
+_Click image below to view a video of this installation/setup process in youtube_
+[![Malt VSCode config](https://img.youtube.com/vi/UjsW7Ce0BKo/maxresdefault.jpg)](http://www.youtube.com/watch?v=UjsW7Ce0BKo "Malt VSCode config")
 
 ## First Contact
 

--- a/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
+++ b/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
@@ -25,7 +25,7 @@ But we can make our lifes much easier by using a code editor.
 
 Now we can make changes in our shader file and as soon as we save it (*Ctrl+S*) Malt will reload it.
 
-Note: When you save the blend file in step 1 and *Malt* is active it will auto-create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
+Note: When you save the blend file in step 1 and *Malt* is active it will create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
 
 _Click image below to view a video of this installation/setup process in youtube_
 [![Malt VSCode config](https://img.youtube.com/vi/UjsW7Ce0BKo/maxresdefault.jpg)](http://www.youtube.com/watch?v=UjsW7Ce0BKo "Malt VSCode config")

--- a/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
+++ b/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
@@ -27,8 +27,7 @@ Now we can make changes in our shader file and as soon as we save it (*Ctrl+S*) 
 
 Note: When you save the blend file in step 1 and *Malt* is active it will create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
 
-_Click image below to view a video of this installation/setup process in youtube_
-[![Malt VSCode config](https://img.youtube.com/vi/UjsW7Ce0BKo/maxresdefault.jpg)](http://www.youtube.com/watch?v=UjsW7Ce0BKo "Malt VSCode config")
+_Having problems with the setup? View a video of this installation/setup process in [YouTube](http://www.youtube.com/watch?v=UjsW7Ce0BKo "Malt VSCode config")_
 
 ## First Contact
 

--- a/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
+++ b/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
@@ -25,7 +25,7 @@ But we can make our lifes much easier by using a code editor.
 
 Now we can make changes in our shader file and as soon as we save it (*Ctrl+S*) Malt will reload it.
 
-Note: When you save the blend file in step 1 and *Malt* is active it will create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
+Note: When you save the blend file in step 1 and the *Malt* renderer is active, it will create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
 
 _Having problems with the setup? View a video of this installation/setup process in [YouTube](http://www.youtube.com/watch?v=UjsW7Ce0BKo "Malt VSCode config")_
 

--- a/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
+++ b/docs/From-Nodes-To-Code/From-Nodes-To-Code.md
@@ -28,6 +28,10 @@ Now we can make changes in our shader file and as soon as we save it (*Ctrl+S*) 
 Note: When you save the blend file in step 1 and the *Malt* renderer is active, it will create a `.vscode` folder in the root of your new folder which includes a `settings.json` file that will help the extensions installed in step 4 work properly.
 
 _Having problems with the setup? View a video of this installation/setup process in [YouTube](http://www.youtube.com/watch?v=UjsW7Ce0BKo "Malt VSCode config")_
+<div style="position: relative; width: 100%; padding-top: 56.25%; /* 16:9 Aspect Ratio */">
+ <iframe style="position: absolute; top: 0; left: 0; bottom: 0;right: 0; width:100%; height:100%; margin:0; border:0;" 
+ src="https://www.youtube-nocookie.com/embed/UjsW7Ce0BKo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+ </div>
 
 ## First Contact
 


### PR DESCRIPTION
I spent a long time trying to figure out why Visual Studio Code kept reporting that my material's header files were missing even though it was being rendered correctly in Blender. 

The problem is that step 2 could be misinterpreted into believing that you should open the `.vscode` folder as a workspace instead of the root of the project. My edits clarify this by moving this extra information below the steps as a final note. 

I also did not notice the YouTube video which would have helped me understand what was happening since the iframe was broken when viewing this file in GitHub which is why I replaced the broken iframe markup with a cleaner link to the video and moved it below all of the steps as a followup for users who are having problems setting this up.