### PR TITLE
fixed persistent nodetree rna warning

### DIFF
--- a/BlenderMalt/MaltNodes/MaltNodeTree.py
+++ b/BlenderMalt/MaltNodes/MaltNodeTree.py
@@ -18,6 +18,8 @@ class MaltTree(bpy.types.NodeTree):
     bl_label = "Malt Node Tree"
     bl_icon = 'NODETREE'
 
+    type : bpy.props.EnumProperty(name = 'Type', items = [("MALT", "Malt", "Malt")])
+
     @classmethod
     def poll(cls, context):
         return context.scene.render.engine == 'MALT'


### PR DESCRIPTION
quick fix to prevent blender from spamming a warning like this whenever you use the Add menu or parts of the node tree UI.

![image](https://user-images.githubusercontent.com/88381426/171907240-57a7d05a-dc5e-4fa6-b3a3-b96bf9ba66ae.png)
