### PR TITLE
make sockets hidden from material by default

### DIFF
--- a/BlenderMalt/MaltNodes/MaltSocket.py
+++ b/BlenderMalt/MaltNodes/MaltSocket.py
@@ -26,7 +26,7 @@ class MaltSocket(bpy.types.NodeSocket):
     default_initialization: bpy.props.StringProperty(default='',
         options={'LIBRARY_EDITABLE'}, override={'LIBRARY_OVERRIDABLE'})
     
-    show_in_material_panel: bpy.props.BoolProperty(default=True,
+    show_in_material_panel: bpy.props.BoolProperty(default=False,
         options={'LIBRARY_EDITABLE'}, override={'LIBRARY_OVERRIDABLE'})
     
     active: bpy.props.BoolProperty(default=True,


### PR DESCRIPTION
this might be a personal preference but I found that having all sockets exposed to the material panel by default clutters that space a lot.

With everything exposed by default you get a very long list of overridable malt parameters which means you have to spend some time searching for those parameters you ACTUALLY want to override OR you have to manually disable this option on all nodes in your node tree. 