### PR TITLE
Light shader redesign

### DIFF
--- a/Malt/Pipelines/NPR_Pipeline/NPR_Pipeline.py
+++ b/Malt/Pipelines/NPR_Pipeline/NPR_Pipeline.py
@@ -177,7 +177,7 @@ class NPR_Pipeline(Pipeline):
             name='Light',
             graph_type=GLSLPipelineGraph.INTERNAL_GRAPH,
             default_global_scope=_LIGHT_SHADER_HEADER,
-            default_shader_src="void LIGHT_SHADER(LightShaderInput I, inout LightShaderOutput O) { }",
+            default_shader_src="void LIGHT_SHADER(vec3 relative_coordinates, inout vec3 color, inout float attenuation) { }",
             graph_io=[ 
                 GLSLGraphIO(
                     name='LIGHT_SHADER',

--- a/Malt/Pipelines/NPR_Pipeline/NPR_Pipeline.py
+++ b/Malt/Pipelines/NPR_Pipeline/NPR_Pipeline.py
@@ -177,7 +177,7 @@ class NPR_Pipeline(Pipeline):
             name='Light',
             graph_type=GLSLPipelineGraph.INTERNAL_GRAPH,
             default_global_scope=_LIGHT_SHADER_HEADER,
-            default_shader_src="void LIGHT_SHADER(vec3 relative_coordinates, inout vec3 color, inout float attenuation) { }",
+            default_shader_src="void LIGHT_SHADER(vec3 relative_coordinates, vec3 uvw, inout vec3 color, inout float attenuation) { }",
             graph_io=[ 
                 GLSLGraphIO(
                     name='LIGHT_SHADER',


### PR DESCRIPTION
This simplifies the Light Shader IO and provides a better behavior for the light space mappings.
It also exposes light attenuation as a separate value that can be left as-is even when changing the light color.

![imagen](https://user-images.githubusercontent.com/36610999/176461620-24bade09-fe45-4d18-a9dd-e50b760be5d9.png)

See #341 for context.

This breaks backward compatibility, but since Light Shaders is a rarely used feature I think it should be ok. (?)