### PR TITLE
fix fractal noise avg strength

### DIFF
--- a/Malt/Shaders/Procedural/Fractal_Noise.glsl
+++ b/Malt/Shaders/Procedural/Fractal_Noise.glsl
@@ -11,16 +11,19 @@
 vec4 fractal_noise_ex(vec4 coord, int octaves, bool tile, vec4 tile_size)
 {
     vec4 result = vec4(0);
-    float strength = 0.5;
+    float strength = 1.0;
+    float max_strength = 0.0;
 
     for (int i = 0; i < octaves; i++) 
-    {
-        result += strength * noise_ex(coord, tile, tile_size);
+    {   
+        vec4 noise = noise_ex(coord, tile, tile_size);
+        result += strength * noise;
+        max_strength += strength;
         coord *= 2.0;
         tile_size *= 2.0;
         strength *= 0.5;
     }
-    return result;
+    return result / max_strength;
 }
 
 

--- a/Malt/Shaders/Procedural/Fractal_Noise.glsl
+++ b/Malt/Shaders/Procedural/Fractal_Noise.glsl
@@ -12,18 +12,18 @@ vec4 fractal_noise_ex(vec4 coord, int octaves, bool tile, vec4 tile_size)
 {
     vec4 result = vec4(0);
     float strength = 1.0;
-    float max_strength = 0.0;
+    float total_strength = 0.0;
 
     for (int i = 0; i < octaves; i++) 
     {   
         vec4 noise = noise_ex(coord, tile, tile_size);
         result += strength * noise;
-        max_strength += strength;
+        total_strength += strength;
+        strength *= 0.5;
         coord *= 2.0;
         tile_size *= 2.0;
-        strength *= 0.5;
     }
-    return result / max_strength;
+    return result / total_strength;
 }
 
 


### PR DESCRIPTION
this branch makes a small change to the fractal noise function. It normalizes the result of accumulated octaves to always have an average value of 0.5 for all channels