### PR TITLE
node-UX organize categories

### DIFF
--- a/BlenderMalt/MaltNodes/MaltNodeTree.py
+++ b/BlenderMalt/MaltNodes/MaltNodeTree.py
@@ -1,5 +1,4 @@
 import os, time
-from itertools import chain
 from Malt.SourceTranspiler import GLSLTranspiler, PythonTranspiler
 import bpy
 from BlenderMalt.MaltProperties import MaltPropertyGroup
@@ -376,21 +375,6 @@ def preload_menus(structs, functions, graph=None):
 
     from nodeitems_utils import NodeCategory, NodeItem, register_node_categories, unregister_node_categories
 
-    def custom_item_draw(self, layout, _context): # Copied and modified from the nodeitems_utils module
-        props = layout.operator("node.add_node", text=self.label, text_ctxt=self.translation_context, icon='OUTLINER')
-        props.type = self.nodetype
-        props.use_transform = True
-
-        for setting in self.settings.items():
-            ops = props.settings.add()
-            ops.name = setting[0]
-            ops.value = setting[1]
-
-    subcategory_node_item = type('SubcategoryNodeItem', (NodeItem,),{
-        'draw':staticmethod(custom_item_draw)
-    }
-    )
-
     category_id = f'BLENDERMALT_{graph.name.upper()}'
 
     try:
@@ -467,8 +451,7 @@ def preload_menus(structs, functions, graph=None):
             settings = OrderedDict(settings)
             # name must be set first for labels to work correctly
             settings.move_to_end('name', last=False)
-            node_item_class = subcategory_node_item if subcategory else NodeItem
-            node_item = node_item_class(_node_type, label=label, settings=settings)
+            node_item = NodeItem(_node_type, label=label, settings=settings)
             categories[category].append(node_item)
 
     add_to_category(functions, 'MaltFunctionNode')

--- a/BlenderMalt/MaltNodes/MaltNodeTree.py
+++ b/BlenderMalt/MaltNodes/MaltNodeTree.py
@@ -469,6 +469,8 @@ def preload_menus(structs, functions, graph=None):
             
     category_list = []
     for category_name, node_items in categories.items():
+        if not len(node_items):
+            continue
         bl_id = f'{category_id}_{category_name}'
         bl_id = ''.join(c for c in bl_id if c.isalnum())
         if len(bl_id) > 64:

--- a/Malt/Pipelines/NPR_Pipeline/Shaders/NPR_Pipeline/NPR_Filters.glsl
+++ b/Malt/Pipelines/NPR_Pipeline/Shaders/NPR_Pipeline/NPR_Filters.glsl
@@ -15,10 +15,11 @@
 */
 
 /*  META
-    @samples: default=32;
-    @radius: default=1.0;
+    @meta: label=AO;
+    @samples: default=32; min=1;
+    @radius: default=1.0; min=0.0;
     @distribution_exponent: default=5.0;
-    @bias: default=0.01;
+    @bias: default=0.01; subtype=Slider; min=0.0; max=1.0;
 */
 float ao(int samples, float radius, float distribution_exponent, float bias)
 {
@@ -70,8 +71,8 @@ float surface_curvature(float depth_range)
 
 /*  META
     @meta: category=Vector; subcategory=Bevel;
-    @samples: default=32;
-    @radius: default=0.02;
+    @samples: default=32; min=1;
+    @radius: default=0.02; min=0.0;
     @distribution_exponent: default=2.0;
 */
 vec3 soft_bevel(int samples, float radius, float distribution_exponent, bool only_self)
@@ -91,8 +92,8 @@ vec3 soft_bevel(int samples, float radius, float distribution_exponent, bool onl
 
 /*  META
     @meta: category=Vector; subcategory=Bevel;
-    @samples: default=32;
-    @radius: default=0.01;
+    @samples: default=32; min=1;
+    @radius: default=0.01; min=0.0;
     @max_dot: default=0.75;
 */
 vec3 hard_bevel(int samples, float radius, float max_dot, bool only_self)

--- a/Malt/Pipelines/NPR_Pipeline/Shaders/NPR_Pipeline/NPR_Filters.glsl
+++ b/Malt/Pipelines/NPR_Pipeline/Shaders/NPR_Pipeline/NPR_Filters.glsl
@@ -19,7 +19,7 @@
     @samples: default=32; min=1;
     @radius: default=1.0; min=0.0;
     @distribution_exponent: default=5.0;
-    @bias: default=0.01; subtype=Slider; min=0.0; max=1.0;
+    @bias: default=0.01; min=0.0; max=1.0;
 */
 float ao(int samples, float radius, float distribution_exponent, float bias)
 {

--- a/Malt/Pipelines/NPR_Pipeline/Shaders/NPR_Pipeline/NPR_Mesh.glsl
+++ b/Malt/Pipelines/NPR_Pipeline/Shaders/NPR_Pipeline/NPR_Mesh.glsl
@@ -113,7 +113,7 @@ vec3 toon_shading(float size, float gradient_size, float specularity, float offs
     return result;
 }
 
-/*META @meta: category=Input; subcategory=Pass Info;*/
+/*META @meta: category=Input; subcategory=Pass Info; internal=true;*/
 bool is_shadow_pass()
 {
     #ifdef SHADOW_PASS
@@ -126,7 +126,7 @@ bool is_shadow_pass()
     }
     #endif
 }
-/*META @meta: category=Input; subcategory=Pass Info;*/
+/*META @meta: category=Input; subcategory=Pass Info; internal=true;*/
 bool is_pre_pass()
 {
     #ifdef PRE_PASS
@@ -139,7 +139,7 @@ bool is_pre_pass()
     }
     #endif
 }
-/*META @meta: category=Input; subcategory=Pass Info;*/
+/*META @meta: category=Input; subcategory=Pass Info; internal=true;*/
 bool is_main_pass()
 {
     #ifdef MAIN_PASS
@@ -152,5 +152,15 @@ bool is_main_pass()
     }
     #endif
 }
+/*META @meta: category=Input; */
+void pass_info(
+    out bool main_pass,
+    out bool pre_pass,
+    out bool shadow_pass
+    ) {
+        main_pass = is_main_pass();
+        pre_pass = is_pre_pass();
+        shadow_pass = is_shadow_pass();
+    }
 
 #endif //NPR_MESH_GLSL

--- a/Malt/Pipelines/NPR_Pipeline/Shaders/NPR_Pipeline/NPR_Mesh.glsl
+++ b/Malt/Pipelines/NPR_Pipeline/Shaders/NPR_Pipeline/NPR_Mesh.glsl
@@ -8,7 +8,7 @@
     @meta: category=Shading;
 */
 
-/* META @meta: subcategory=Simple Diffuse;*/
+/* META @meta: subcategory=NPR Diffuse;*/
 vec3 diffuse_shading()
 {
     vec3 result = vec3(0);
@@ -19,7 +19,7 @@ vec3 diffuse_shading()
     return result;
 }
 
-/* META @meta: subcategory=Simple Diffuse;*/
+/* META @meta: subcategory=NPR Diffuse;*/
 vec3 diffuse_half_shading()
 {
     vec3 result = vec3(0);
@@ -30,7 +30,7 @@ vec3 diffuse_half_shading()
     return result;
 }
 
-/* META @meta: subcategory=Simple Diffuse;*/
+/* META @meta: subcategory=NPR Diffuse;*/
 vec3 diffuse_gradient_shading(sampler1D gradient_texture)
 {
     vec3 result = vec3(0);
@@ -42,7 +42,7 @@ vec3 diffuse_gradient_shading(sampler1D gradient_texture)
 }
 
 /*  META
-    @meta: subcategory=Simple Specular;
+    @meta: subcategory=NPR Specular;
     @tangent: subtype=Normal; default=radial_tangent(NORMAL, vec3(0,0,1));
     @anisotropy: default=0.5;
     @roughness: default=0.5;
@@ -58,7 +58,7 @@ vec3 specular_shading(float roughness)
 }
 
 /*  META
-    @meta: subcategory=Simple Specular;
+    @meta: subcategory=NPR Specular;
     @roughness: default=0.5;
 */
 vec3 specular_gradient_shading(sampler1D gradient_texture, float roughness)
@@ -72,7 +72,7 @@ vec3 specular_gradient_shading(sampler1D gradient_texture, float roughness)
 }
 
 /*  META
-    @meta: subcategory=Simple Specular;
+    @meta: subcategory=NPR Specular;
     @roughness: default=0.5;
     @anisotropy: default=0.5;
     @tangent: subtype=Normal; default=radial_tangent(NORMAL, vec3(0,0,1));
@@ -88,7 +88,7 @@ vec3 specular_anisotropic_shading(float roughness, float anisotropy, vec3 tangen
 }
 
 /*  META
-    @meta: subcategory=Simple Specular;
+    @meta: subcategory=NPR Specular;
     @roughness: default=0.5;
     @anisotropy: default=0.5;
     @tangent: subtype=Normal; default=radial_tangent(NORMAL, vec3(0,0,1));
@@ -103,6 +103,7 @@ vec3 specular_anisotropic_gradient_shading(sampler1D gradient_texture, float rou
     return result;
 }
 
+/* META @meta: label=NPR Toon Shading; */
 vec3 toon_shading(float size, float gradient_size, float specularity, float offset)
 {
     vec3 result = vec3(0);
@@ -154,13 +155,13 @@ bool is_main_pass()
 }
 /*META @meta: category=Input; */
 void pass_info(
-    out bool main_pass,
-    out bool pre_pass,
-    out bool shadow_pass
+    out bool Is_Main_Pass,
+    out bool Is_Pre_Pass,
+    out bool Is_Shadow_Pass
     ) {
-        main_pass = is_main_pass();
-        pre_pass = is_pre_pass();
-        shadow_pass = is_shadow_pass();
+        Is_Main_Pass = is_main_pass();
+        Is_Pre_Pass = is_pre_pass();
+        Is_Shadow_Pass = is_shadow_pass();
     }
 
 #endif //NPR_MESH_GLSL

--- a/Malt/Shaders/Common/Color.glsl
+++ b/Malt/Shaders/Common/Color.glsl
@@ -39,6 +39,7 @@ float luma(vec3 color)
     return dot(color, vec3(0.299,0.587,0.114));
 }
 
+/* META @meta: label=Linear To sRGB; */
 vec3 linear_to_srgb(vec3 linear)
 {
     vec3 low = linear * 12.92;
@@ -46,6 +47,7 @@ vec3 linear_to_srgb(vec3 linear)
     return mix(low, high, greaterThan(linear, vec3(0.0031308)));
 }
 
+/* META @meta: label=sRGB To Linear; */
 vec3 srgb_to_linear(vec3 srgb)
 {
     vec3 low = srgb / 12.92;
@@ -53,6 +55,7 @@ vec3 srgb_to_linear(vec3 srgb)
     return mix(low, high, greaterThan(srgb, vec3(0.04045)));
 }
 
+/* META @meta: label=RGB To HSV; */
 vec3 rgb_to_hsv(vec3 rgb)
 {
     rgb = linear_to_srgb(rgb);
@@ -67,6 +70,7 @@ vec3 rgb_to_hsv(vec3 rgb)
 }
 
 /*  META
+    @meta: label=HSV To RGB;
     @hsv:subtype=HSV;
 */
 vec3 hsv_to_rgb(vec3 hsv)
@@ -76,6 +80,7 @@ vec3 hsv_to_rgb(vec3 hsv)
     return srgb_to_linear(hsv.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), hsv.y));
 }
 
+/* META @meta: label=HSV Edit; */
 vec4 hsv_edit(vec4 color, float hue, float saturation, float value)
 {
     vec3 hsv = rgb_to_hsv(color.rgb);
@@ -83,6 +88,7 @@ vec4 hsv_edit(vec4 color, float hue, float saturation, float value)
     return vec4(hsv_to_rgb(hsv), color.a);
 }
 
+/* META @meta: label=RGB Gradient; */
 vec3 rgb_gradient(sampler1D gradient, vec3 uvw)
 {
     return vec3
@@ -93,6 +99,7 @@ vec3 rgb_gradient(sampler1D gradient, vec3 uvw)
     );
 }
 
+/* META @meta: label=RGBA Gradient; */
 vec4 rgba_gradient(sampler1D gradient, vec4 uvw)
 {
     return vec4

--- a/Malt/Shaders/Common/Hash.glsl
+++ b/Malt/Shaders/Common/Hash.glsl
@@ -31,20 +31,20 @@ vec4 _pcg4d(vec4 v)
 }
 
 /*  META
-    @meta: subcategory=Hash;
+    @meta: subcategory=Hash; label=Hash 1D;
 */
 vec4 hash(float v){ return _pcg4d(vec4(v,0,0,0)); }
 /*  META
-    @meta: subcategory=Hash;
+    @meta: subcategory=Hash; label=Hash 2D;
 */
 vec4 hash(vec2  v){ return _pcg4d(vec4(v,0,0)); }
 /*  META
-    @meta: subcategory=Hash;
+    @meta: subcategory=Hash; label=Hash 3D;
     @v:subtype=Data;
 */
 vec4 hash(vec3  v){ return _pcg4d(vec4(v,0)); }
 /*  META
-    @meta: subcategory=Hash;
+    @meta: subcategory=Hash; label=Hash 4D;
     @v:subtype=Data;
 */
 vec4 hash(vec4  v){ return _pcg4d(v); }

--- a/Malt/Shaders/Common/Mapping.glsl
+++ b/Malt/Shaders/Common/Mapping.glsl
@@ -11,6 +11,7 @@ vec3 view_direction();
 vec3 transform_normal(mat4 matrix, vec3 normal);
 
 /*  META
+	@meta: label=Matcap UV;
     @normal: subtype=Normal; default=NORMAL;
 */
 vec2 matcap_uv(vec3 normal)
@@ -45,6 +46,7 @@ vec4 sample_matcap(sampler2D matcap, vec3 normal)
 }
 
 /*  META
+	@meta: label=HDRI UV;
     @normal: subtype=Normal; default=NORMAL;
 */
 vec2 hdri_uv(vec3 normal)
@@ -55,7 +57,7 @@ vec2 hdri_uv(vec3 normal)
 }
 
 /*  META
-	@meta: category=Texturing;
+	@meta: category=Texturing; label=Sample HDRI;
     @normal: subtype=Normal; default=NORMAL;
 */
 vec4 sample_hdri(sampler2D hdri, vec3 normal)

--- a/Malt/Shaders/Common/Mapping.glsl
+++ b/Malt/Shaders/Common/Mapping.glsl
@@ -4,7 +4,7 @@
 #include "Common.glsl"
 
 /* META GLOBAL
-    @meta: category=Input;
+    @meta: category=Vector;
 */
 
 vec3 view_direction();

--- a/Malt/Shaders/Common/Math.glsl
+++ b/Malt/Shaders/Common/Math.glsl
@@ -34,6 +34,7 @@
 
 #include "Common.glsl"
 
+/* META @meta: subcategory=Random; */
 vec4 random_per_sample(float seed)
 {
     return hash(vec2(float(SAMPLE_COUNT), seed));
@@ -41,6 +42,7 @@ vec4 random_per_sample(float seed)
 
 vec2 screen_uv(); //FORWARD DECLARATION
 
+/* META @meta: subcategory=Random; */
 vec4 random_per_pixel(float seed) 
 {
     return hash(vec4(screen_uv(), float(SAMPLE_COUNT), seed));

--- a/Malt/Shaders/Common/Matrix.glsl
+++ b/Malt/Shaders/Common/Matrix.glsl
@@ -2,7 +2,7 @@
 #define COMMON_MATRIX_GLSL
 
 /* META GLOBAL
-    @meta: category=Vector;
+    @meta: category=Math; subcategory=Mat4;
 */
 
 #include "Common/Quaternion.glsl"

--- a/Malt/Shaders/Common/Normal.glsl
+++ b/Malt/Shaders/Common/Normal.glsl
@@ -8,7 +8,7 @@
 #include "Common.glsl"
 
 /* META
-    @meta: category=Input;
+    @meta: category=Input; internal=true;
 */
 vec3 true_normal()
 {
@@ -30,7 +30,7 @@ vec3 true_normal()
 }
 
 /* META
-    @meta: category=Input;
+    @meta: category=Input; internal=true;
 */
 float facing()
 {
@@ -38,7 +38,7 @@ float facing()
 }
 
 /* META
-    @meta: category=Input;
+    @meta: category=Input; internal=true;
 */
 bool is_front_facing()
 {
@@ -105,9 +105,12 @@ vec3 get_bitangent(int uv_index)
     return normalize(cross(NORMAL, T.xyz) * T.w);
 }
 
-/* META
-    @meta: category=Input;
-*/
+/* META @meta: internal=true; */
+vec3 get_incoming(vec3 view_location, vec3 surface_position){
+    return normalize( view_location - surface_position );
+}
+
+/* META @meta: subcategory=Tangent; */
 mat3 get_TBN(int uv_index)
 {
     mat3 TBN = mat3(get_tangent(uv_index), get_bitangent(uv_index), NORMAL);
@@ -139,7 +142,7 @@ vec3 sample_normal_map(sampler2D normal_texture, int uv_index, vec2 uv)
 /*  META
     @meta: category=Vector; subcategory=Tangent;
     @normal: subtype=Normal; default=NORMAL;
-    @axis: subtype=Normal; default=(0,0,1);
+    @axis: subtype=Normal; default=(0.0,0.0,1.0);
 */
 vec3 radial_tangent(vec3 normal, vec3 axis)
 {

--- a/Malt/Shaders/Common/Normal.glsl
+++ b/Malt/Shaders/Common/Normal.glsl
@@ -50,6 +50,7 @@ bool is_front_facing()
     return facing() > 0;
 }
 
+/* META @meta: subcategory=Tangent; */
 vec4 compute_tangent(vec2 uv)
 {
     // Copyright (c) 2020 mmikk. MIT License
@@ -89,18 +90,14 @@ vec4 compute_tangent(vec2 uv)
     return vec4(0);
 }
 
-/* META
-    @meta: category=Input;
-*/
+/* META @meta: subcategory=Tangent; */
 vec3 get_tangent(int uv_index)
 {
     if(PRECOMPUTED_TANGENTS && uv_index == 0) return TANGENT;
     return compute_tangent(UV[uv_index]).xyz;
 }
 
-/* META
-    @meta: category=Input;
-*/
+/* META @meta: subcategory=Tangent; */
 vec3 get_bitangent(int uv_index)
 {
     if(PRECOMPUTED_TANGENTS && uv_index == 0) return BITANGENT;
@@ -125,6 +122,7 @@ mat3 get_TBN(int uv_index)
     return TBN;
 }
 
+/* META @meta: category=Texturing; subcategory=Normal Map; */
 vec3 sample_normal_map_ex(sampler2D normal_texture, mat3 TBN, vec2 uv)
 {
     vec3 tangent = texture(normal_texture, uv).xyz;
@@ -132,12 +130,14 @@ vec3 sample_normal_map_ex(sampler2D normal_texture, mat3 TBN, vec2 uv)
     return normalize(TBN * tangent);
 }
 
+/* META @meta: category=Texturing; subcategory=Normal Map; */
 vec3 sample_normal_map(sampler2D normal_texture, int uv_index, vec2 uv)
 {
     return sample_normal_map_ex(normal_texture, get_TBN(uv_index), uv);
 }
 
 /*  META
+    @meta: category=Vector; subcategory=Tangent;
     @normal: subtype=Normal; default=NORMAL;
     @axis: subtype=Normal; default=(0,0,1);
 */

--- a/Malt/Shaders/Common/Normal.glsl
+++ b/Malt/Shaders/Common/Normal.glsl
@@ -125,7 +125,11 @@ mat3 get_TBN(int uv_index)
     return TBN;
 }
 
-/* META @meta: category=Texturing; subcategory=Normal Map; */
+/* META 
+    @meta: category=Texturing; internal=true;
+    @TBN: default=get_TBN(0);
+    @uv: default=UV[0]; label=UV;
+*/
 vec3 sample_normal_map_ex(sampler2D normal_texture, mat3 TBN, vec2 uv)
 {
     vec3 tangent = texture(normal_texture, uv).xyz;
@@ -133,7 +137,11 @@ vec3 sample_normal_map_ex(sampler2D normal_texture, mat3 TBN, vec2 uv)
     return normalize(TBN * tangent);
 }
 
-/* META @meta: category=Texturing; subcategory=Normal Map; */
+/* META 
+    @meta: category=Texturing; label=Normal Map; 
+    @uv_index: min=0; max=3;
+    @uv: default=UV[0];
+*/
 vec3 sample_normal_map(sampler2D normal_texture, int uv_index, vec2 uv)
 {
     return sample_normal_map_ex(normal_texture, get_TBN(uv_index), uv);

--- a/Malt/Shaders/Common/Quaternion.glsl
+++ b/Malt/Shaders/Common/Quaternion.glsl
@@ -2,7 +2,7 @@
 #define COMMON_QUATERNION_GLSL
 
 /*  META GLOBAL
-    @meta: category=Math;
+    @meta: category=Math; subcategory=Quaternion;
 */
 
 

--- a/Malt/Shaders/Common/Transform.glsl
+++ b/Malt/Shaders/Common/Transform.glsl
@@ -88,7 +88,7 @@ ivec2 screen_pixel()
     #endif
 }
 /* META
-    @meta: interal=false;
+    @meta: internal=false;
     @uv: default=screen_uv();
 */
 vec3 screen_to_camera(vec2 uv, float depth)
@@ -117,12 +117,12 @@ float pixel_depth()
     return 0.0;
 }
 
-/* META @meta: category=Math; interal=false; */
+/* META @meta: category=Math; internal=false; */
 float depth_to_z(float depth)
 {
     return screen_to_camera(vec2(0,0), depth).z;
 }
-/* META @meta: category=Math; interal=false; */
+/* META @meta: category=Math; internal=false; */
 float pixel_world_size_at(float depth)
 {
     vec2 uv = screen_uv();

--- a/Malt/Shaders/Common/Transform.glsl
+++ b/Malt/Shaders/Common/Transform.glsl
@@ -49,19 +49,19 @@ vec3 transform_normal(mat4 matrix, vec3 normal)
     return normalize(m * normal);
 }
 
-/* META @meta: category=Input; subcategory=Camera Info; */
+/* META @meta: category=Input; subcategory=Camera Info; internal=true;*/
 vec3 camera_position()
 {
     return transform_point(inverse(CAMERA), vec3(0,0,0));
 }
 
-/* META @meta: category=Input; */
+/* META @meta: category=Input; internal=true;*/
 vec3 model_position()
 {
     return transform_point(MODEL, vec3(0,0,0));
 }
 
-/* META @meta: category=Input; subcategory=Camera Info; */
+/* META @meta: category=Input; subcategory=Camera Info; internal=true; */
 vec2 screen_uv()
 {
     #ifdef PIXEL_SHADER
@@ -75,6 +75,7 @@ vec2 screen_uv()
     #endif //PIXEL_SHADER
 }
 
+/* META @meta: internal=true; */
 ivec2 screen_pixel()
 {
     #ifdef PIXEL_SHADER
@@ -99,12 +100,13 @@ vec3 screen_to_camera(vec2 uv, float depth)
     return camera_position.xyz;
 }
 
-/* META @meta: category=Input; subcategory=Camera Info; */
+/* META @meta: category=Input; subcategory=Camera Info; internal=true;*/
 vec3 view_direction()
 {
     return transform_normal(inverse(CAMERA), screen_to_camera(screen_uv(), 1));
 }
 
+/* META @meta: internal=true; */
 float pixel_depth()
 {
     #ifdef PIXEL_SHADER
@@ -116,11 +118,12 @@ float pixel_depth()
     return 0.0;
 }
 
+/* META @meta: category=Math; */
 float depth_to_z(float depth)
 {
     return screen_to_camera(vec2(0,0), depth).z;
 }
-
+/* META @meta: category=Math; */
 float pixel_world_size_at(float depth)
 {
     vec2 uv = screen_uv();
@@ -128,6 +131,7 @@ float pixel_world_size_at(float depth)
     return distance(screen_to_camera(uv, depth), screen_to_camera(uv + offset, depth));
 }
 
+/* META @meta: internal=true; */
 float pixel_world_size()
 {
     #ifdef PIXEL_SHADER

--- a/Malt/Shaders/Common/Transform.glsl
+++ b/Malt/Shaders/Common/Transform.glsl
@@ -8,6 +8,7 @@
 #include "Common.glsl"
 
 /*  META
+    @meta: subcategory=Transformation;
     @matrix: default=mat4(1);
     @point: subtype=Vector;
 */
@@ -17,6 +18,7 @@ vec3 transform_point(mat4 matrix, vec3 point)
 }
 
 /*  META
+    @meta: subcategory=Transformation;
     @matrix: default=mat4(1);
     @point: subtype=Vector;
 */
@@ -27,6 +29,7 @@ vec3 project_point(mat4 matrix, vec3 point)
 }
 
 /*  META
+    @meta: subcategory=Transformation;
     @matrix: default=mat4(1);
     @direction: subtype=Vector;
 */
@@ -36,6 +39,7 @@ vec3 transform_direction(mat4 matrix, vec3 direction)
 }
 
 /*  META
+    @meta: subcategory=Transformation;
     @matrix: default=mat4(1);
     @normal: subtype=Normal;
 */
@@ -45,16 +49,19 @@ vec3 transform_normal(mat4 matrix, vec3 normal)
     return normalize(m * normal);
 }
 
+/* META @meta: category=Input; subcategory=Camera Info; */
 vec3 camera_position()
 {
     return transform_point(inverse(CAMERA), vec3(0,0,0));
 }
 
+/* META @meta: category=Input; */
 vec3 model_position()
 {
     return transform_point(MODEL, vec3(0,0,0));
 }
 
+/* META @meta: category=Input; subcategory=Camera Info; */
 vec2 screen_uv()
 {
     #ifdef PIXEL_SHADER
@@ -80,7 +87,9 @@ ivec2 screen_pixel()
     }
     #endif
 }
-
+/* META
+    @uv: default=screen_uv();
+*/
 vec3 screen_to_camera(vec2 uv, float depth)
 {
     vec3 clip_position = vec3(uv, depth) * 2.0 - 1.0;
@@ -90,6 +99,7 @@ vec3 screen_to_camera(vec2 uv, float depth)
     return camera_position.xyz;
 }
 
+/* META @meta: category=Input; subcategory=Camera Info; */
 vec3 view_direction()
 {
     return transform_normal(inverse(CAMERA), screen_to_camera(screen_uv(), 1));

--- a/Malt/Shaders/Common/Transform.glsl
+++ b/Malt/Shaders/Common/Transform.glsl
@@ -2,13 +2,13 @@
 #define COMMON_TRANSFORM_GLSL
 
 /*  META GLOBAL
-    @meta: category=Vector;
+    @meta: category=Vector; internal=true;
 */
 
 #include "Common.glsl"
 
 /*  META
-    @meta: subcategory=Transformation;
+    @meta: subcategory=Transformation; internal=false;
     @matrix: default=mat4(1);
     @point: subtype=Vector;
 */
@@ -18,7 +18,7 @@ vec3 transform_point(mat4 matrix, vec3 point)
 }
 
 /*  META
-    @meta: subcategory=Transformation;
+    @meta: subcategory=Transformation; internal=false;
     @matrix: default=mat4(1);
     @point: subtype=Vector;
 */
@@ -29,7 +29,7 @@ vec3 project_point(mat4 matrix, vec3 point)
 }
 
 /*  META
-    @meta: subcategory=Transformation;
+    @meta: subcategory=Transformation; internal=false;
     @matrix: default=mat4(1);
     @direction: subtype=Vector;
 */
@@ -39,7 +39,7 @@ vec3 transform_direction(mat4 matrix, vec3 direction)
 }
 
 /*  META
-    @meta: subcategory=Transformation;
+    @meta: subcategory=Transformation; internal=false;
     @matrix: default=mat4(1);
     @normal: subtype=Normal;
 */
@@ -49,19 +49,19 @@ vec3 transform_normal(mat4 matrix, vec3 normal)
     return normalize(m * normal);
 }
 
-/* META @meta: category=Input; subcategory=Camera Info; internal=true;*/
+/* META @meta: category=Input; */
 vec3 camera_position()
 {
     return transform_point(inverse(CAMERA), vec3(0,0,0));
 }
 
-/* META @meta: category=Input; internal=true;*/
+/* META @meta: category=Input; */
 vec3 model_position()
 {
     return transform_point(MODEL, vec3(0,0,0));
 }
 
-/* META @meta: category=Input; subcategory=Camera Info; internal=true; */
+/* META @meta: category=Input; */
 vec2 screen_uv()
 {
     #ifdef PIXEL_SHADER
@@ -75,7 +75,6 @@ vec2 screen_uv()
     #endif //PIXEL_SHADER
 }
 
-/* META @meta: internal=true; */
 ivec2 screen_pixel()
 {
     #ifdef PIXEL_SHADER
@@ -89,6 +88,7 @@ ivec2 screen_pixel()
     #endif
 }
 /* META
+    @meta: interal=false;
     @uv: default=screen_uv();
 */
 vec3 screen_to_camera(vec2 uv, float depth)
@@ -100,13 +100,12 @@ vec3 screen_to_camera(vec2 uv, float depth)
     return camera_position.xyz;
 }
 
-/* META @meta: category=Input; subcategory=Camera Info; internal=true;*/
+/* META @meta: category=Input; */
 vec3 view_direction()
 {
     return transform_normal(inverse(CAMERA), screen_to_camera(screen_uv(), 1));
 }
 
-/* META @meta: internal=true; */
 float pixel_depth()
 {
     #ifdef PIXEL_SHADER
@@ -118,12 +117,12 @@ float pixel_depth()
     return 0.0;
 }
 
-/* META @meta: category=Math; */
+/* META @meta: category=Math; interal=false; */
 float depth_to_z(float depth)
 {
     return screen_to_camera(vec2(0,0), depth).z;
 }
-/* META @meta: category=Math; */
+/* META @meta: category=Math; interal=false; */
 float pixel_world_size_at(float depth)
 {
     vec2 uv = screen_uv();
@@ -131,7 +130,6 @@ float pixel_world_size_at(float depth)
     return distance(screen_to_camera(uv, depth), screen_to_camera(uv + offset, depth));
 }
 
-/* META @meta: internal=true; */
 float pixel_world_size()
 {
     #ifdef PIXEL_SHADER
@@ -154,6 +152,7 @@ vec3 _reconstruct_cs_position(sampler2D depth_texture, int depth_channel, ivec2 
     return screen_to_camera(uv, depth);
 }
 
+ /* META @meta: internal=false; */
 vec3 reconstruct_normal(sampler2D depth_texture, int depth_channel, ivec2 texel)
 {
     vec3 t0 = _reconstruct_cs_position(depth_texture, depth_channel, texel);
@@ -186,6 +185,7 @@ float ray_plane_intersection(vec3 ray_origin, vec3 ray_direction, vec3 plane_pos
     return (p_position - r_origin) / r_direction;
 }
 
+/* META @meta: internal=false; */
 vec2 rotate_2d(vec2 p, float angle)
 {
     float c = cos(angle);

--- a/Malt/Shaders/Filters/Blur.glsl
+++ b/Malt/Shaders/Filters/Blur.glsl
@@ -7,7 +7,7 @@
 
 /*  META
     @uv: default=screen_uv();
-    @radius: default=5.0;
+    @radius: default=5.0; min=0.0;
 */
 vec4 box_blur(sampler2D input_texture, vec2 uv, float radius, bool circular)
 {
@@ -48,7 +48,7 @@ float _gaussian_weight_2d(vec2 v, float sigma)
 
 /*  META
     @uv: default=screen_uv();
-    @radius: default=5.0;
+    @radius: default=5.0; min=0.0;
     @sigma: default=1.0;
 */
 vec4 gaussian_blur(sampler2D input_texture, vec2 uv, float radius, float sigma)
@@ -78,7 +78,7 @@ vec4 gaussian_blur(sampler2D input_texture, vec2 uv, float radius, float sigma)
     @uv: default=screen_uv();
     @radius: default=5.0;
     @distribution_exponent: default=5.0;
-    @samples: default=8;
+    @samples: default=8; min=1;
 */
 vec4 jitter_blur(sampler2D input_texture, vec2 uv, float radius, float distribution_exponent, int samples)
 {

--- a/Malt/Shaders/Node Utils/Input.glsl
+++ b/Malt/Shaders/Node Utils/Input.glsl
@@ -1,0 +1,97 @@
+#ifndef NODE_UTILS_INPUT_GLSL
+#define NODE_UTILS_INPUT_GLSL
+
+/* META GLOBAL
+    @meta: category=Input;
+*/
+
+void geometry(
+    int uv_index,
+    out vec3 position,
+    out vec3 normal,
+    out vec3 tangent,
+    out vec3 bitangent,
+    out vec3 incoming,
+    out vec3 out_true_normal,
+    out float facing,
+    out bool front_facing
+    ) {
+        position = POSITION;
+        normal = NORMAL;
+        tangent = get_tangent(uv_index);
+        bitangent = get_bitangent(uv_index);
+        incoming = get_incoming(camera_position(), position);
+        out_true_normal = true_normal();
+        facing = dot(normal, incoming);
+        front_facing = is_front_facing();
+}
+
+vec4 vertex_color( int index ){
+    return COLOR[index];
+}
+
+vec2 uv_map( int index ){
+    return UV[index];
+}
+
+void object_info(
+    out vec3 location,
+    out mat4 object_matrix,
+    out float object_distance,
+    out vec4 random
+    ) {
+        location = (MODEL * vec4(0.0, 0.0, 0.0, 1.0)).xyz;
+        object_matrix = MODEL;
+        object_distance = distance((CAMERA * vec4( 0.0, 0.0, 0.0, 1.0)).xyz, location);
+        random = hash(unpackUnorm4x8(IO_ID.x).xy);
+    } 
+
+void id(
+    out uvec4 id,
+    out uvec4 original_id
+    ) {
+        id = ID;
+        original_id = IO_ID;
+    }
+
+int _get_fps(){ return int(round(FRAME / TIME));}
+
+void time(
+    out int frame,
+    out float time,
+    out int fps
+    ) {
+        frame = FRAME;
+        time = TIME;
+        fps = _get_fps();
+    }
+
+void render(
+    out vec2 render_resolution,
+    out vec2 sample_offset,
+    out int sample_count,
+    out float out_pixel_depth,
+    out float out_pixel_world_size
+    ) {
+        render_resolution = vec2(RESOLUTION);
+        sample_offset = SAMPLE_OFFSET;
+        sample_count = SAMPLE_COUNT;
+        out_pixel_depth = pixel_depth();
+        out_pixel_world_size = pixel_world_size();
+    }
+
+void camera(
+    out vec3 location,
+    out vec3 direction,
+    out vec2 window,
+    out mat4 camera_matrix,
+    out mat4 projection_matrix
+    ) {
+        location = camera_position();
+        direction = view_direction();
+        window = screen_uv();
+        camera_matrix = CAMERA;
+        projection_matrix = PROJECTION;
+    }
+
+#endif // NODE_UTILS_INPUT_GLSL

--- a/Malt/Shaders/Node Utils/Input.glsl
+++ b/Malt/Shaders/Node Utils/Input.glsl
@@ -3,33 +3,46 @@
 
 /* META GLOBAL
     @meta: category=Input;
+    @out_true_normal: label=True Normal;
 */
 
 void geometry(
-    int uv_index,
     out vec3 position,
     out vec3 normal,
-    out vec3 tangent,
-    out vec3 bitangent,
     out vec3 incoming,
-    out vec3 out_true_normal,
-    out float facing,
+    out vec3 True_Normal,
     out bool front_facing
     ) {
         position = POSITION;
         normal = NORMAL;
-        tangent = get_tangent(uv_index);
-        bitangent = get_bitangent(uv_index);
         incoming = get_incoming(camera_position(), position);
-        out_true_normal = true_normal();
-        facing = dot(normal, incoming);
+        True_Normal = true_normal();
         front_facing = is_front_facing();
 }
 
+/* META
+    @position: default=POSITION; subtype=Vector;
+    @normal: default=NORMAL; subtype=Vector;
+*/
+void layer_weight(
+    vec3 position,
+    vec3 normal,
+    out float facing,
+    out float fresnel
+    ) {
+        facing = dot( normal, get_incoming(camera_position(), position));
+        fresnel = 0.5; // WIP
+    }
+
+/* META @index: min=0; max=3; */
 vec4 vertex_color( int index ){
     return COLOR[index];
 }
 
+/* META 
+    @meta: label=UV Map;
+    @index: min=0; max=3;
+*/
 vec2 uv_map( int index ){
     return UV[index];
 }
@@ -45,7 +58,7 @@ void object_info(
         object_distance = distance((CAMERA * vec4( 0.0, 0.0, 0.0, 1.0)).xyz, location);
         random = hash(unpackUnorm4x8(IO_ID.x).xy);
     } 
-
+/* META @meta: label=ID; */
 void id(
     out uvec4 id,
     out uvec4 original_id
@@ -54,30 +67,26 @@ void id(
         original_id = IO_ID;
     }
 
-int _get_fps(){ return int(round(FRAME / TIME));}
-
 void time(
     out int frame,
-    out float time,
-    out int fps
+    out float time
     ) {
         frame = FRAME;
         time = TIME;
-        fps = _get_fps();
     }
 
 void render(
     out vec2 render_resolution,
     out vec2 sample_offset,
     out int sample_count,
-    out float out_pixel_depth,
-    out float out_pixel_world_size
+    out float Pixel_Depth,
+    out float Pixel_World_Size
     ) {
         render_resolution = vec2(RESOLUTION);
         sample_offset = SAMPLE_OFFSET;
         sample_count = SAMPLE_COUNT;
-        out_pixel_depth = pixel_depth();
-        out_pixel_world_size = pixel_world_size();
+        Pixel_Depth = pixel_depth();
+        Pixel_World_Size = pixel_world_size();
     }
 
 void camera(

--- a/Malt/Shaders/Node Utils/Texturing.glsl
+++ b/Malt/Shaders/Node Utils/Texturing.glsl
@@ -1,0 +1,40 @@
+#ifndef NODE_UTILS_TEXTURING_GLSL
+#define NODE_UTILS_TEXTURING_GLSL
+
+#include "Procedural/Fractal_Noise.glsl"
+#include "Procedural/Cell_Noise.glsl"
+
+/* META GLOBAL
+    @meta: category=Texturing;
+*/
+
+/*  META
+    @coord: subtype=Vector; default=vec4(POSITION,0);
+    @detail: default=3.0; min=1.0;
+    @roughness: subtype=Slider; min=0.0; max=1.0; default = 0.5;
+    @tile_size: subtype=Vector; default=vec4(1);
+*/
+vec4 noise( vec4 coord, float detail, float roughness, bool tile, vec4 tile_size ){
+
+    return fractal_noise_ex(coord, detail, roughness, tile, tile_size);
+}
+
+/* META
+    @coord: subtype=Vector; default=vec4(POSITION,0);
+    @tile_size: subtype=Vector; default = vec4(1.0);
+*/
+void voronoi( 
+    vec4 coord, 
+    bool tile, 
+    vec4 tile_size,
+    out vec4 cell_color,
+    out vec3 cell_position,
+    out float cell_distance
+    ) {
+        CellNoiseResult result = cell_noise_ex(coord, tile, tile_size);
+        cell_color = result.cell_color;
+        cell_position = result.cell_position;
+        cell_distance = result.cell_distance;
+    }
+
+#endif //NODE_UTILS_TEXTURING_GLSL

--- a/Malt/Shaders/Node Utils/common.glsl
+++ b/Malt/Shaders/Node Utils/common.glsl
@@ -5,45 +5,45 @@
     @meta: category=Input;
 */
 
-/*META @meta: subcategory=Surface;*/
+/*META @meta: subcategory=Surface; internal=true;*/
 vec3 surface_position() { return POSITION; }
-/*META @meta: subcategory=Surface;*/
+/*META @meta: subcategory=Surface; internal=true;*/
 vec3 surface_normal() { return NORMAL; }
-/*META @meta: subcategory=Surface;*/
+/*META @meta: subcategory=Surface; internal=true;*/
 vec3 surface_tangent(int index) { return get_tangent(index); }
-/*META @meta: subcategory=Surface;*/
+/*META @meta: subcategory=Surface; internal=true;*/
 vec3 surface_bitangent(int index) { return get_bitangent(index); }
-/*META @meta: subcategory=Surface;*/
+/*META @meta: subcategory=Surface; internal=true;*/
 vec2 surface_uv(int index) { return UV[index]; }
-/*META @meta: subcategory=Surface;*/
+/*META @meta: subcategory=Surface; internal=true;*/
 vec4 surface_vertex_color(int index) { return COLOR[index]; }
-/*META @meta: subcategory=Surface;*/
+/*META @meta: subcategory=Surface; internal=true;*/
 vec3 surface_original_position() { return IO_POSITION; }
-/*META @meta: subcategory=Surface;*/
+/*META @meta: subcategory=Surface; internal=true;*/
 vec3 surface_original_normal() { return IO_NORMAL; }
 
-/*META @meta: subcategory=Object ID;*/
+/*META @meta: internal=true; */
 uvec4 object_id() { return ID; }
-/*META @meta: subcategory=Object ID;*/
+/*META @meta: internal=true; */
 uvec4 object_original_id() { return IO_ID; }
 
-/*META @meta: subcategory=Matrices;*/
+/*META @meta: internal=true; */
 mat4 model_matrix() { return MODEL; }
-/*META @meta: subcategory=Matrices;*/
+/*META @meta: internal=true; */
 mat4 camera_matrix() { return CAMERA; }
-/*META @meta: subcategory=Matrices;*/
+/*META @meta: internal=true; */
 mat4 projection_matrix() { return PROJECTION; }
 
-/*META @meta: subcategory=Render Info;*/
+/*META @meta: internal=true; */
 vec2 render_resolution() { return vec2(RESOLUTION); }
-/*META @meta: subcategory=Render Info;*/
+/*META @meta: internal=true; */
 vec2 sample_offset() { return SAMPLE_OFFSET; }
-/*META @meta: subcategory=Render Info;*/
+/*META @meta: internal=true; */
 int sample_count() { return SAMPLE_COUNT; }
 
-/*META @meta: subcategory=Time Info;*/
+/*META @meta: internal=true; */
 int current_frame() { return FRAME; }
-/*META @meta: subcategory=Time Info;*/
+/*META @meta: internal=true; */
 float current_time() { return TIME; }
 
 #endif // NODE_UTILS_COMMON_GLSL

--- a/Malt/Shaders/Node Utils/common.glsl
+++ b/Malt/Shaders/Node Utils/common.glsl
@@ -2,48 +2,38 @@
 #define NODE_UTILS_COMMON_GLSL
 
 /*  META GLOBAL
-    @meta: category=Input;
+    @meta: category=Input; internal=true;
 */
 
-/*META @meta: subcategory=Surface; internal=true;*/
+/*META @meta: subcategory=Surface; */
 vec3 surface_position() { return POSITION; }
-/*META @meta: subcategory=Surface; internal=true;*/
+/*META @meta: subcategory=Surface; */
 vec3 surface_normal() { return NORMAL; }
-/*META @meta: subcategory=Surface; internal=true;*/
+/*META @meta: subcategory=Surface; */
 vec3 surface_tangent(int index) { return get_tangent(index); }
-/*META @meta: subcategory=Surface; internal=true;*/
+/*META @meta: subcategory=Surface; */
 vec3 surface_bitangent(int index) { return get_bitangent(index); }
-/*META @meta: subcategory=Surface; internal=true;*/
+/*META @meta: subcategory=Surface; */
 vec2 surface_uv(int index) { return UV[index]; }
-/*META @meta: subcategory=Surface; internal=true;*/
+/*META @meta: subcategory=Surface; */
 vec4 surface_vertex_color(int index) { return COLOR[index]; }
-/*META @meta: subcategory=Surface; internal=true;*/
+/*META @meta: subcategory=Surface; */
 vec3 surface_original_position() { return IO_POSITION; }
-/*META @meta: subcategory=Surface; internal=true;*/
+/*META @meta: subcategory=Surface; */
 vec3 surface_original_normal() { return IO_NORMAL; }
 
-/*META @meta: internal=true; */
 uvec4 object_id() { return ID; }
-/*META @meta: internal=true; */
 uvec4 object_original_id() { return IO_ID; }
 
-/*META @meta: internal=true; */
 mat4 model_matrix() { return MODEL; }
-/*META @meta: internal=true; */
 mat4 camera_matrix() { return CAMERA; }
-/*META @meta: internal=true; */
 mat4 projection_matrix() { return PROJECTION; }
 
-/*META @meta: internal=true; */
 vec2 render_resolution() { return vec2(RESOLUTION); }
-/*META @meta: internal=true; */
 vec2 sample_offset() { return SAMPLE_OFFSET; }
-/*META @meta: internal=true; */
 int sample_count() { return SAMPLE_COUNT; }
 
-/*META @meta: internal=true; */
 int current_frame() { return FRAME; }
-/*META @meta: internal=true; */
 float current_time() { return TIME; }
 
 #endif // NODE_UTILS_COMMON_GLSL

--- a/Malt/Shaders/Node Utils/mat4.glsl
+++ b/Malt/Shaders/Node Utils/mat4.glsl
@@ -1,0 +1,16 @@
+#ifndef MAT4_GLSL
+#define MAT4_GLSL
+
+/*  META GLOBAL
+    @meta: category=Math; subcategory=Mat4;
+*/
+
+/*  META
+    @matrix: default=mat4(1);
+*/
+mat4 mat4_inverse(mat4 matrix)
+{
+    return inverse(matrix);
+}
+
+#endif //MAT4_GLSL

--- a/Malt/Shaders/Node Utils/node_utils.glsl
+++ b/Malt/Shaders/Node Utils/node_utils.glsl
@@ -14,6 +14,9 @@
 #include "Node Utils/vec3.glsl"
 #include "Node Utils/vec4.glsl"
 
+#include "Node Utils/Input.glsl"
+#include "Node Utils/Texturing.glsl"
+
 // Basic common API
 #include "Common.glsl"
 #include "Filters/AO.glsl"

--- a/Malt/Shaders/Node Utils/node_utils.glsl
+++ b/Malt/Shaders/Node Utils/node_utils.glsl
@@ -6,6 +6,7 @@
 #include "Node Utils/bool.glsl"
 #include "Node Utils/float.glsl"
 #include "Node Utils/int.glsl"
+#include "Node Utils/mat4.glsl"
 #include "Node Utils/packing.glsl"
 #include "Node Utils/properties.glsl"
 #include "Node Utils/sampler.glsl"

--- a/Malt/Shaders/Node Utils/sampler.glsl
+++ b/Malt/Shaders/Node Utils/sampler.glsl
@@ -5,7 +5,10 @@
     @meta: category=Texturing;
 */
 
-/*META @meta: subcategory=Color Ramp;*/
+/*META 
+    @meta: subcategory=Color Ramp;
+    @u: subtype=Slider; min=0.0; max=1.0;
+*/
 vec4 sampler1D_sample(sampler1D t, float u) { return texture(t, u); }
 /*META @meta: subcategory=Color Ramp;*/
 int sampler1D_size(sampler1D t) { return textureSize(t, 0); }

--- a/Malt/Shaders/Procedural/Cell_Noise.glsl
+++ b/Malt/Shaders/Procedural/Cell_Noise.glsl
@@ -4,7 +4,7 @@
 #include "Common/Hash.glsl"
 
 /*  META GLOBAL
-    @meta: category=Texturing; subcategory=Cell Noise;
+    @meta: category=Texturing; internal=true;
 */
 
 struct CellNoiseResult

--- a/Malt/Shaders/Procedural/Fractal_Noise.glsl
+++ b/Malt/Shaders/Procedural/Fractal_Noise.glsl
@@ -4,11 +4,10 @@
 #include "Noise.glsl"
 
 /*  META GLOBAL
-    @meta: category=Texturing;
+    @meta: category=Texturing; @meta: internal=true;
 */
 
 /*  META
-    @meta: internal=true;
     @coord: subtype=Vector; default=vec4(POSITION,0);
     @detail: default=3.0; min=1.0;
     @roughness: subtype=Slider; min=0.0; max=1.0; default = 0.5;
@@ -35,15 +34,18 @@ vec4 fractal_noise_ex(vec4 coord, float detail, float roughness, bool tile, vec4
     return result / total_weight;
 }
 
+vec4 fractal_noise_ex(vec4 coord, int octaves, bool tile, vec4 tile_size){
+    return fractal_noise_ex(coord, float(octaves), 0.5, tile, tile_size);
+}
+
 
 /*  META
-    @meta: internal=true;
     @coord: subtype=Vector; default=vec4(POSITION,0);
     @detail: default=3;
 */
-vec4 fractal_noise(vec4 coord, float detail, float roughness)
+vec4 fractal_noise(vec4 coord, int octaves)
 {
-    return fractal_noise_ex(coord, detail, roughness, false, vec4(0));
+    return fractal_noise_ex(coord, float(octaves), 0.0, false, vec4(0));
 }
 
 #endif // PROCEDURAL_FRACTAL_NOISE_GLSL

--- a/Malt/Shaders/Procedural/Fractal_Noise.glsl
+++ b/Malt/Shaders/Procedural/Fractal_Noise.glsl
@@ -4,37 +4,46 @@
 #include "Noise.glsl"
 
 /*  META GLOBAL
-    @meta: category=Texturing; subcategory=Fractal Noise;
+    @meta: category=Texturing;
 */
 
 /*  META
+    @meta: internal=true;
     @coord: subtype=Vector; default=vec4(POSITION,0);
-    @octaves: default=3;
+    @detail: default=3.0; min=1.0;
+    @roughness: subtype=Slider; min=0.0; max=1.0; default = 0.5;
     @tile_size: subtype=Vector; default=vec4(1);
 */
-vec4 fractal_noise_ex(vec4 coord, int octaves, bool tile, vec4 tile_size)
+vec4 fractal_noise_ex(vec4 coord, float detail, float roughness, bool tile, vec4 tile_size)
 {
     vec4 result = vec4(0);
-    float strength = 0.5;
+    float weight = 1.0;
+    float total_weight = 0.0;
+    roughness = clamp(roughness, 0.00001, 1.0);
+    detail = max(1.0, detail);
 
-    for (int i = 0; i < octaves; i++) 
-    {
-        result += strength * noise_ex(coord, tile, tile_size);
+    for (int i = 0; i < ceil(detail); i++) 
+    {   
+        vec4 noise = noise_ex(coord, tile, tile_size);
+        float octave_weight = (i + 1 > floor(detail))? mod(detail, 1.0) : 1.0;
+        weight *= roughness * 2 * octave_weight;
+        result += weight * noise;
+        total_weight += weight;
         coord *= 2.0;
         tile_size *= 2.0;
-        strength *= 0.5;
     }
-    return result;
+    return result / total_weight;
 }
 
 
 /*  META
+    @meta: internal=true;
     @coord: subtype=Vector; default=vec4(POSITION,0);
-    @octaves: default=3;
+    @detail: default=3;
 */
-vec4 fractal_noise(vec4 coord, int octaves)
+vec4 fractal_noise(vec4 coord, float detail, float roughness)
 {
-    return fractal_noise_ex(coord, octaves, false, vec4(0));
+    return fractal_noise_ex(coord, detail, roughness, false, vec4(0));
 }
 
 #endif // PROCEDURAL_FRACTAL_NOISE_GLSL


### PR DESCRIPTION
I made the default categories deterministic (defined them up front).
Also organized the functions a bit more. I guess the exact order is a bit subjective. Let me know what you think.
Also made it clear from the category UI which nodes have subcategories. This was originally to keep track of where we have subcategories but it might be nice to keep it in as an actual feature.

There are still some functions in the 'Vector' category that I dont know what they do exactly and therefore can not group or move to a different category:
![image](https://user-images.githubusercontent.com/88381426/179395262-cecd1ed0-b7c6-4e2a-94dd-d32b6c49713a.png)
