### PR TITLE
node-ux: display function labels on nodes

### DIFF
--- a/BlenderMalt/MaltNodes/Nodes/MaltFunctionNode.py
+++ b/BlenderMalt/MaltNodes/Nodes/MaltFunctionNode.py
@@ -210,6 +210,12 @@ class MaltFunctionNodeBase(MaltNode):
                     self.malt_parameters.draw_parameter(layout, 'PASS_GRAPH', None, is_node_socket=True)
                 else:
                     self.malt_parameters.draw_parameter(layout, 'PASS_MATERIAL', None, is_node_socket=True)
+    
+    def get_function_label(self):
+        return self.get_function().get('meta', {}).get('label', self.name)
+    
+    def draw_label(self):
+        return self.get_function_label()
 
 
 class MaltFunctionNode(bpy.types.Node, MaltFunctionNodeBase):

--- a/BlenderMalt/MaltNodes/Nodes/MaltFunctionSubCategory.py
+++ b/BlenderMalt/MaltNodes/Nodes/MaltFunctionSubCategory.py
@@ -5,7 +5,7 @@ class MaltFunctionSubCategoryNode(bpy.types.Node, MaltFunctionNodeBase):
 
     bl_label = "Function SubCategory Node"
 
-    subcategory : bpy.props.StringProperty(options={'LIBRARY_EDITABLE'}, override={'LIBRARY_OVERRIDABLE'})
+    subcategory : bpy.props.StringProperty(options={'LIBRARY_EDITABLE'}, override={'LIBRARY_OVERRIDABLE'}) 
 
     def get_function_enums(self, context=None):
         items = []
@@ -32,8 +32,8 @@ class MaltFunctionSubCategoryNode(bpy.types.Node, MaltFunctionNodeBase):
         if self.hide:
             label = self.get_function()['meta'].get('label', None)
             if label:
-                return self.name + ' - ' + label
-        return self.name
+                return self.subcategory + ' - ' + label
+        return self.subcategory
 
 
 def register():


### PR DESCRIPTION
Displaying the function labels on nodes would be more inline with blenders own nodes.
Pros: looks nicer, shorter labels and therefore more readable
Cons: Node label does not reflect name shown on the material overrides panel. 