### PR TITLE
node-ux---width-calculation

### DIFF
--- a/BlenderMalt/MaltNodes/MaltNode.py
+++ b/BlenderMalt/MaltNodes/MaltNode.py
@@ -156,36 +156,31 @@ class MaltNode():
     def should_delete_outdated_links(self):
         return False
     
-    def setup_width(self):
-        size = bpy.context.preferences.ui_styles[0].widget_label.points
-        dpi = 72 #dont use bpy.context.preferences.system.dpi because that is influenced by the UI scale but the node widths are not
-        import blf
-        blf.size(0, size, dpi)
+    def calc_node_width(self, point_size, dpi) -> float:
+        import blf 
+        blf.size(0, point_size, dpi)
         header_padding = 36 # account for a little space for the arrow icon + extra padding on the side of a label
         socket_padding = 31 # account for little offset of the text from the node border
 
         def adjust_width(width, text, scale=1, padding=0):
             new_width = blf.dimensions(0, text)[0] * scale + padding
-            print(text, 'has', new_width, 'width')
             result = max(width, new_width)
             return result
 
-        print('-'*20)
-        # max_width = blf.dimensions(0, self.draw_label())[0] + header_padding
         max_width = adjust_width(0, self.draw_label(), padding=header_padding)
         for input in self.inputs.values():
             scale = 2 
             if input.default_initialization or '.' in input.name:
                 scale = 1
-            # max_width = max(max_width, blf.dimensions(0, input.get_ui_label())[0] * scale + socket_padding)
             max_width = adjust_width(max_width, input.get_ui_label(), scale=scale, padding=socket_padding*scale)
         for output in self.outputs.values():
-            # max_width = max(max_width, blf.dimensions(0, output.get_ui_label())[0] + socket_padding)
             max_width = adjust_width(max_width, output.get_ui_label(), padding=socket_padding)
-        # self.width = max(max_width, 140)
-        self.width = max_width
-        print('Final Width:', self.width)
-        return self.width
+        return max_width
+
+    def setup_width(self):
+        point_size = bpy.context.preferences.ui_styles[0].widget_label.points
+        dpi = 72 #dont use bpy.context.preferences.system.dpi because that is influenced by the UI scale but the node widths are not 
+        self.width = self.calc_node_width(point_size, dpi)
 
     def get_source_name(self):
         return self.id_data.get_transpiler().get_source_name(self.name)

--- a/BlenderMalt/MaltNodes/MaltNode.py
+++ b/BlenderMalt/MaltNodes/MaltNode.py
@@ -154,18 +154,35 @@ class MaltNode():
             self.setup_width()
     
     def setup_width(self):
-        size = bpy.context.preferences.ui_styles[0].widget.points
+        size = bpy.context.preferences.ui_styles[0].widget_label.points
+        dpi = 72 #dont use bpy.context.preferences.system.dpi because that is influenced by the UI scale but the node widths are not
         import blf
-        blf.size(0, size, 90) 
-        max_width = blf.dimensions(0, self.name)[0]
+        blf.size(0, size, dpi)
+        header_padding = 36 # account for a little space for the arrow icon + extra padding on the side of a label
+        socket_padding = 31 # account for little offset of the text from the node border
+
+        def adjust_width(width, text, scale=1, padding=0):
+            new_width = blf.dimensions(0, text)[0] * scale + padding
+            print(text, 'has', new_width, 'width')
+            result = max(width, new_width)
+            return result
+
+        print('-'*20)
+        # max_width = blf.dimensions(0, self.draw_label())[0] + header_padding
+        max_width = adjust_width(0, self.draw_label(), padding=header_padding)
         for input in self.inputs.values():
             scale = 2 
             if input.default_initialization or '.' in input.name:
                 scale = 1
-            max_width = max(max_width, blf.dimensions(0, input.get_ui_label())[0] * scale)
+            # max_width = max(max_width, blf.dimensions(0, input.get_ui_label())[0] * scale + socket_padding)
+            max_width = adjust_width(max_width, input.get_ui_label(), scale=scale, padding=socket_padding*scale)
         for output in self.outputs.values():
-            max_width = max(max_width, blf.dimensions(0, output.get_ui_label())[0])
-        self.width = max(max_width, 200)
+            # max_width = max(max_width, blf.dimensions(0, output.get_ui_label())[0] + socket_padding)
+            max_width = adjust_width(max_width, output.get_ui_label(), padding=socket_padding)
+        # self.width = max(max_width, 140)
+        self.width = max_width
+        print('Final Width:', self.width)
+        return self.width
 
     def get_source_name(self):
         return self.id_data.get_transpiler().get_source_name(self.name)

--- a/BlenderMalt/MaltNodes/Nodes/MaltFunctionSubCategory.py
+++ b/BlenderMalt/MaltNodes/Nodes/MaltFunctionSubCategory.py
@@ -33,6 +33,14 @@ class MaltFunctionSubCategoryNode(bpy.types.Node, MaltFunctionNodeBase):
         layout.prop(self, 'function_enum')
         return super().draw_buttons(context, layout)
     
+    def calc_node_width(self, point_size, dpi) -> float:
+        import blf
+        blf.size(0, point_size, dpi)
+        max_width = super().calc_node_width(point_size, dpi)
+        layout_padding = 50 # account for the spaces on both sides of the enum dropdown
+        label = next(enum[1] for enum in self.get_function_enums() if enum[0]==self.function_enum)
+        return max(max_width, blf.dimensions(0, label)[0] + layout_padding)
+
     def draw_label(self):
         if self.hide:
             label = self.get_function()['meta'].get('label', None)


### PR DESCRIPTION
I wanted to improve the width calculation for the nodes. I wanted to be able to make them as tight as possible so that any descreasing of the node results in 'text cutoff'. 

The changed portion is currently very verbose for testing so I would not merge this immediately.
Also this is a separate PR and not a commit to the node-ux branch because it uses 3 'magic numbers'. They work really well (at least for me) though but I cant say for sure for other machines.

What do you think?