### PR TITLE
Remove dpi arguments of blf.size() calls, which were causing exceptions frequently

### DIFF
--- a/BlenderMalt/MaltNodes/MaltNodeUITools.py
+++ b/BlenderMalt/MaltNodes/MaltNodeUITools.py
@@ -302,7 +302,7 @@ class OT_MaltCycleSubCategories(bpy.types.Operator):
         batch.draw(shader)
         gpu.state.blend_set('NONE')
 
-        blf.size(font_id, label_style.points * zoom, 72)
+        blf.size(font_id, label_style.points * zoom)
         blf.color(font_id, 1,1,1,1)
 
         for i, e in enumerate(reversed(prev_enums)):
@@ -483,10 +483,9 @@ class MaltNodeDrawCallbacks:
         text = ' > '.join(x.node_tree.name for x in path)
         preferences = context.preferences
         ui_scale = preferences.view.ui_scale
-        dpi = preferences.system.dpi
         size = preferences.ui_styles[0].widget.points * ui_scale
         color = preferences.themes[0].node_editor.space.text
-        blf.size(font_id, size, dpi)
+        blf.size(font_id, size)
         blf.position(font_id, 10, 10, 0)
         blf.color(font_id, *color, 1)
         blf.draw(font_id, text)
@@ -518,7 +517,7 @@ class MaltNodeDrawCallbacks:
         color = (Vector(socket.draw_color(context, node)) + Vector((1,1,1,1))) * 0.5
 
         def draw_text(text: str, size: float, loc: tuple[float, float], color: tuple[float, float, float, float]):
-            blf.size(font_id, size, 72)
+            blf.size(font_id, size)
             blf.position(font_id, *loc, 0)
             blf.color(font_id, *color)
             blf.draw(font_id, text)


### PR DESCRIPTION
Blender's Python API got a breaking change: https://wiki.blender.org/wiki/Reference/Release_Notes/4.0/Python_API
I guess you already know that, I saw some changes about it in some previous commits.
But there are some other calls in MaltNodeUITools.py which are ignored, and are still causing exceptions.

Malt actually works fine without fixing this, but when I run blender from a terminal (so that I can get more info, like dependency cycle info, when things go wrong), the terminal will be literally flooded with useless exceptions complaining that "blf.size() takes 2 arguments but 3 were given", given that the exception raises from some rendering codes which are executed frequently.

Not sure what's the original intention of using dpi info here, but the texts displayed seem to have coherent and reasonable sizes on both 1920x1080 and 3840x2160 displays, after applying this change.