### PR TITLE
Fix render crash when in edit mode

### DIFF
--- a/BlenderMalt/MaltMeshes.py
+++ b/BlenderMalt/MaltMeshes.py
@@ -19,7 +19,7 @@ def load_mesh(object, name):
     from . import CBlenderMalt
 
     m = object.data
-    if object.type != 'MESH' or bpy.context.mode == 'EDIT_MESH':
+    if object.type != 'MESH' or object.mode == 'EDIT':
         m = object.to_mesh()
     
     if m is None or len(m.polygons) == 0:


### PR DESCRIPTION
Rendering with a mesh that has a boolean modifier and its set to display in edit mode and that mesh is currently being edited then blender will crash. 

```
0x00007fff8b2bd465 in retrieve_mesh_data (in_positions=0x0, in_loop_verts=0x0, loop_count=42, 
    in_loop_tris=0x7fff2f00a8d8, in_loop_tri_polys=0x7fff37d7c498, loop_tri_count=24, in_mat_indices=0x0, 
    out_positions=0x7fff4045e000, out_indices=0x7fff3d14ec80, out_index_lengths=0x7fff3d14dc30)
    at Malt/BlenderMalt/CBlenderMalt/CBlenderMalt.cpp:20
20          out_positions[i*3+0] = in_positions[in_loop_verts[i]*3+0];
```

I figured out that `bpy.context.mode` is always `OBJECT` during rendering causing `to_mesh()` to not be called, so checking the specific objects mode instead fixes this issue. 

This is a blend file that repos the issue:
[malt-crash.zip](https://github.com/user-attachments/files/20544850/malt-crash.zip)