### PR TITLE
Use system mcpp on Linux

### DIFF
--- a/Malt/GL/Shader.py
+++ b/Malt/GL/Shader.py
@@ -169,6 +169,17 @@ def shader_preprocessor(shader_source, include_directories=[], definitions=[]):
     dependencies_path = os.path.join(os.path.dirname(__file__), '..', f'.Dependencies-{py_version}')
     mcpp = os.path.join(dependencies_path, f'mcpp-{platform.system()}')
 
+    if platform.system() == "Linux":
+        # NixOS and Guix System will cannot run the included mcpp binary
+        result = subprocess.run(f'"{mcpp}"', shell=True, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        if result.returncode != 0:
+            # Search for system mcpp
+            for directory in os.get_exec_path():
+                path = os.path.join(directory, "mcpp")
+                if os.path.isfile(path) and os.access(path, os.X_OK):
+                    mcpp = path
+
+
     command = f'"{mcpp}"'
     command += ' -C' #keep comments
     for directory in include_directories:


### PR DESCRIPTION
Certain Linux distributions such as NixOS and Guix System cannot run dynamically linked executables intended for generic Linux systems. Thus the mcpp executable included in Malt will not run on them. With this PR, Malt on Linux will search the system PATH for an installed mcpp executable and will use that instead of the included binary if one is found.