### PR TITLE
Bump python version for Blender 5.1

### DIFF
--- a/.github/workflows/BlenderMalt.yml
+++ b/.github/workflows/BlenderMalt.yml
@@ -75,7 +75,7 @@ jobs:
         
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     
     - name: setup_blender_addon.py
       run: python setup_blender_addon.py --copy-modules

--- a/.github/workflows/BlenderMalt.yml
+++ b/.github/workflows/BlenderMalt.yml
@@ -73,10 +73,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
         
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     
+    - name: install setuptools
+      run: pip install setuptools
+
     - name: setup_blender_addon.py
       run: python setup_blender_addon.py --copy-modules
       working-directory: ${{ github.workspace }}/scripts


### PR DESCRIPTION
3.11 -> 3.13

I also had to add `pip install setuptools` because the `distutils` import in `install_dependencies.py` fails on 3.13